### PR TITLE
Add html templating and tei-publisher-lib as dependencies of apps

### DIFF
--- a/profiles/base10/expath-pkg.tpl.xml
+++ b/profiles/base10/expath-pkg.tpl.xml
@@ -3,4 +3,6 @@
     <title>[[ head(($pkg?title, $label)) ]]</title>
     <dependency processor="http://exist-db.org" semver-min="6.2.0" />
     <dependency package="http://e-editiones.org/roaster" semver="1"/>
+    <dependency package="http://exist-db.org/html-templating" semver="1"/>
+    <dependency package="http://existsolutions.com/apps/tei-publisher-lib" semver="4"/>
 </package>


### PR DESCRIPTION
They are dependencies. Without them, the app won't start.

Fixes #21 