### PR TITLE
Ignore XML declarations when computing a hash

### DIFF
--- a/modules/cpy.xql
+++ b/modules/cpy.xql
@@ -193,7 +193,9 @@ declare %private function cpy:overwrite($context as map(*), $relPath as xs:strin
 };
 
 declare %private function cpy:hash($content as xs:string) {
-    util:hash(replace($content, "[\s\n\r]+", " "), "sha-256")
+    (: Remove whitespace and XML version tags. These are not relevant for the actual hash :)
+		(: TODO: self-closing elements are also not important, neither is attribute order. They can have the same hash :)
+    util:hash(replace($content, "(<?[xX][mM][lL](^\?)*?>)|[\s\n\r]+", " "), "sha-256")
 };
 
 declare %private function cpy:scan-resources($root as xs:anyURI, $func as function(xs:anyURI, xs:anyURI?) as item()*) {


### PR DESCRIPTION
Many files in the project had conflicts based on XML version declarations. These are not important at all for hashes, and they can be ignored.

They are likely artifacts from serializing or syncing some files from and to exist-db