### PR TITLE
Add submenu (dropdown list)

### DIFF
--- a/profiles/base10/templates/menu-mobile.html
+++ b/profiles/base10/templates/menu-mobile.html
@@ -6,6 +6,19 @@
             <li>
                 <a href="[[ $context-path ]]/[[ $item?url ]]"><pb-i18n key="menu.[[ $item?id ]]">[[ $item?id ]]</pb-i18n></a>
             </li>
+            [% elif exists($item?subitems) %]
+            <li>
+                <details class="dropdown">
+                    <summary><pb-i18n key="menu.[[ $item?id ]]">[[ $item?id ]]</pb-i18n></summary>
+                    <ul dir="rtl">
+                        [% for $subitem in $item?subitems?* %]
+                        <li>
+                            <a href="[[ $context-path ]]/[[ $subitem?url ]]"><pb-i18n key="menu.[[ $subitem?id ]]">[[ $subitem?id ]]</pb-i18n></a>
+                        </li>
+                        [% endfor %]
+                    </ul>
+                </details>
+            </li>
             [% endif %]
             [% endfor %]
             [% if $menu?language %]

--- a/profiles/base10/templates/menu.html
+++ b/profiles/base10/templates/menu.html
@@ -4,7 +4,20 @@
         [% for $item in $menu?items?* %]
         [% if $item?url or $item?url = ''%]
         <li class="hidden-mobile">
-            <a href="[[ $context-path ]]/[[ $item?url ]]"><pb-i18n key="menu.[[ $item?id ]]">[[ $item?id ]]</pb-i18n></a>
+            <a href="[[ $context-path ]]/[[ $item?url ]]"><pb-i18n key="menu.[[ $item?id ]]">[[ $item?id ]]</pb-i18n></a>  
+        </li>        
+        [% elif exists($item?subitems) %]
+        <li>
+            <details class="dropdown">
+                <summary><pb-i18n key="menu.[[ $item?id ]]">[[ $item?id ]]</pb-i18n></summary>
+                <ul dir="rtl">
+                    [% for $subitem in $item?subitems?* %]
+                    <li>
+                        <a href="[[ $context-path ]]/[[ $subitem?url ]]"><pb-i18n key="menu.[[ $subitem?id ]]">[[ $subitem?id ]]</pb-i18n></a>
+                    </li>
+                    [% endfor %]
+                </ul>
+            </details>
         </li>
         [% endif %]
         [% endfor %]

--- a/schema/jinks.json
+++ b/schema/jinks.json
@@ -198,11 +198,29 @@
                             },
                             "id": {
                                 "type": "string"
-                            }
+                            },
+                            "subitems": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "id": {
+                                            "type": "string"
+                                            },
+                                        "url": {
+                                            "type": ["string", "null"],
+                                            "description": "URL to link to. Might be null to remove an item inherited from a parent profile."
+                                        }
+                                    },
+                                "required": [
+                                    "id",
+                                    "url"
+                                    ]
+                                }  
+                            }  
                         },
                         "required": [
-                            "id",
-                            "url"
+                            "id"
                         ]
                     }
                 },


### PR DESCRIPTION
This PR includes
- Change in the JSON schema to add the property `subitems`. Since a menu item with a dropdown list shouldn’t be a link, property `url` is no longer required.
- Changes in the HTML templates to add the dropdown list as a `<details>` element