### PR TITLE
fix(landing-page): distinguish browse and landing page

### DIFF
--- a/profiles/base10/config.json
+++ b/profiles/base10/config.json
@@ -56,7 +56,7 @@
     "defaults": {
         "data": "data",
         "data-default": "",
-        "landing": "browse.html",
+        "browse": "browse.html",
         "view": "div",
         "search": "div",
         "odd": "teipublisher.odd",

--- a/profiles/base10/controller.tpl.xql
+++ b/profiles/base10/controller.tpl.xql
@@ -8,7 +8,8 @@ declare variable $exist:controller external;
 declare variable $exist:prefix external;
 declare variable $exist:root external;
 
-declare variable $landingPage := "[[ head(($context?defaults?landing, 'browse.html')) ]]";
+[# Use the first non-empty value from the defaults #]
+declare variable $landingPage := "[[ head(($context?defaults?landing, $context?defaults?browse, 'browse.html')) ]]";
 
 declare variable $allowOrigin := local:allowOriginDynamic(request:get-header("Origin"));
 

--- a/profiles/docs/config.json
+++ b/profiles/docs/config.json
@@ -8,7 +8,7 @@
     "order": 101,
     "defaults": {
         "data-default": "",
-        "landing": "browse-custom.html"
+        "browse": "browse-custom.html"
     },
     "depends": [
         "base10",

--- a/profiles/landing-page/templates/index.html
+++ b/profiles/landing-page/templates/index.html
@@ -36,7 +36,7 @@
             <h1><pb-i18n key="hero.main"></pb-i18n></h1>
             <p>
                 <pb-i18n key="hero.sub"></pb-i18n><br/>
-                <a class="explore-link" href="browse.html"><pb-i18n key="hero.explore"></pb-i18n></a>
+                <a class="explore-link" href="[[ $context?defaults?browse ]]"><pb-i18n key="hero.explore"></pb-i18n></a>
             </p>
         </div>
     </header>

--- a/profiles/playground/config.json
+++ b/profiles/playground/config.json
@@ -13,7 +13,7 @@
     "defaults": {
         "data-default": "playground",
         "template": "basic.html",
-        "landing": "browse-custom.html"
+        "browse": "browse-custom.html"
     },
     "features": {
         "toc": {

--- a/schema/jinks.json
+++ b/schema/jinks.json
@@ -108,6 +108,10 @@
                     "type": "string",
                     "description": "The HTML page to use as landing page. Will be renamed to index.html. Path is relative to the `templates` subdirectory."
                 },
+                "browse": {
+                    "type": "string",
+                    "description": "The HTML page to use for browse available document collections. Path is relative to the `templates` subdirectory."
+                },
                 "view": {
                     "type": "string",
                     "enum": ["div", "page", "single"]


### PR DESCRIPTION
Distinguish browse and landing page in config, so landing page can be added on top of any other profile modifying browse.