### PR TITLE
Bugfix/overwrite modes

### DIFF
--- a/modules/api.json
+++ b/modules/api.json
@@ -201,9 +201,9 @@
                         "schema": {
                             "type": "string",
                             "enum": [
-                                "default",
-                                "force",
-                                "all"
+                                "quick",
+                                "all",
+                                "reinstall"
                             ],
                             "default": "default"
                         },

--- a/modules/cpy.xql
+++ b/modules/cpy.xql
@@ -12,6 +12,10 @@ import module namespace path="http://tei-publisher.com/jinks/path" at "paths.xql
 
 declare namespace expath="http://expath.org/ns/pkg";
 
+declare variable $cpy:OVERWRITE_QUICK := "quick";
+declare variable $cpy:OVERWRITE_ALL := "all";
+declare variable $cpy:OVERWRITE_REINSTALL := "reinstall";
+
 declare variable $cpy:ERROR_NOT_FOUND := xs:QName("cpy:not-found");
 declare variable $cpy:ERROR_TEMPLATE := xs:QName("cpy:template");
 declare variable $cpy:ERROR_CONFLICT := xs:QName("cpy:conflict");
@@ -202,7 +206,7 @@ declare %private function cpy:overwrite($context as map(*), $relPath as xs:strin
             (: Check timestamp of .jinks.json first to determine if source was modified since last run :)
             (: Templated source files should always be updated though :)
             if (
-                $context?_overwrite != "force" and
+                $context?_overwrite != $cpy:OVERWRITE_ALL and
                 not(matches($sourcePath, $context?template-suffix)) and
                 cpy:file-exists($path) and
                 exists($context?_lastModified) and
@@ -219,7 +223,7 @@ declare %private function cpy:overwrite($context as map(*), $relPath as xs:strin
                     if (empty($currentHash) or empty($expectedHash) or $currentHash = $expectedHash) then
                         let $contentHash := cpy:hash($incomingContent, $mime)
                         return
-                            (: Still update if overwrite="update", the file was not there last time,
+                            (: Still update if overwrite="full", the file was not there last time,
                             : or the incoming content is different :)
                             if (empty($expectedHash)
                                 or $contentHash != $expectedHash) then (

--- a/modules/generator.xql
+++ b/modules/generator.xql
@@ -36,9 +36,9 @@ declare function generator:profile-path($name as xs:string) {
  :
  : In the settings, property "overwrite" controls how files in an existing app are updated:
  : 
- : * "overwrite=default": check last modified date of source and if newer, check if content has changed
- : * "overwrite=force": ignore last modified date, enforce content check
- : * "overwrite=all": the entire app is regenerated and then reinstalled
+ : * "overwrite=quick": check last modified date of source and if newer, check if content has changed
+ : * "overwrite=all": ignore last modified date, enforce content check
+ : * "overwrite=reinstall": the entire app is regenerated and then reinstalled
  :   unless local modifications were applied by the user
  :
  : @param $settings general settings to control the generator
@@ -225,11 +225,11 @@ declare %private function generator:config($settings as map(*)?, $userConfig as 
             $config,
             map {
                 "target":
-                    if ($settings?overwrite = "all") then
+                    if ($settings?overwrite = $cpy:OVERWRITE_REINSTALL) then
                         $tempTarget
                     else
                         head(($installedPkg, $tempTarget)),
-                "_update": exists($installedPkg) and $settings?overwrite != "all",
+                "_update": exists($installedPkg) and $settings?overwrite != $cpy:OVERWRITE_REINSTALL,
                 "_overwrite": $settings?overwrite,
                 "_dry": $settings?dry,
                 "template-suffix": "\.tpl"

--- a/pages/index.html
+++ b/pages/index.html
@@ -148,12 +148,12 @@
                 <label>
                     Overwrite mode
                     <select id="overwrite" name="overwrite" placeholder="Overwrite mode">
-                        <option value="default">Default: overwrite files if upstream version changed</option>
-                        <option value="force">Force: ignore last modified date and check every file for changes</option>
-                        <option value="all">All: reinstall everything</option>
+                        <option value="quick">Quick: overwrite files if upstream version changed</option>
+                        <option value="all">All: ignore last modified date and check every file for changes</option>
+                        <option value="reinstall">Factory reset: reinstall everything</option>
                     </select>
-                    <small>Modes <strong>default</strong> and <strong>force</strong> will never overwrite local changes. <strong>Default</strong> mode is faster if applied repeatedly, but 
-                        skips checks on incoming files, which were not modified since last run. For a full list of updates and conflicts, use <strong>force</strong>.</small>
+                    <small>Modes <strong>quick</strong> and <strong>all</strong> will never overwrite local changes. <strong>Quick</strong> mode is faster if applied repeatedly, but 
+                        skips checks on incoming files, which were not modified since last run. For a full list of updates and conflicts, use <strong>all</strong>.</small>
                 </label>
             </fieldset>
             <nav>

--- a/profiles/base10/config.json
+++ b/profiles/base10/config.json
@@ -4,7 +4,7 @@
     "id": "https://e-editiones.org/app/tei-publisher/base",
     "version": "1.0.0",
     "label": "TEI Publisher Base",
-    "description": "Base profile for a TEI Publisher 10 application. Not usable on its own.",
+    "description": "Base profile for a TEI Publisher 10 application. Provides the core API and basic page layout without styling.",
     "order": 0,
     "pkg": {
         "abbrev": "tei-publisher-base",

--- a/resources/scripts/editor.js
+++ b/resources/scripts/editor.js
@@ -239,7 +239,7 @@ window.addEventListener('DOMContentLoaded', () => {
                     !(result.nextStep.action === 'DEPLOY' || result.config._update === false)
                 ) {
                     const li = document.createElement('li');
-                    li.innerHTML = 'No changes detected.';
+                    li.innerHTML = 'Update completed.';
                     output.appendChild(li);
                 } else {
                     result.messages.forEach((message) => {
@@ -395,7 +395,8 @@ window.addEventListener('DOMContentLoaded', () => {
     }
 
     function update(updateEditor = true) {
-        const formData = new FormData(form);
+        // Get the form data
+        let formData = new FormData(form);
         if (formData.get('abbrev') !== '') {
             if (formData.get('label') === '') {
                 form.querySelector('[name="label"]').value = formData.get('abbrev');
@@ -407,8 +408,11 @@ window.addEventListener('DOMContentLoaded', () => {
         if (!formData.get('theme')) {
             form.querySelector('[name="theme"]').checked = true;
         }
-        new FormData(form).forEach((value, key) => {
-            if (key !== 'base' && key !== 'feature' && key !== 'theme' && key !== 'blueprint' && key !== 'abbrev' && key !== 'custom-odd') {
+
+        // Recreate the form data to get the latest values
+        formData = new FormData(form);
+        formData.forEach((value, key) => {
+            if (!['base', 'feature', 'theme', 'blueprint', 'abbrev', 'custom-odd', 'overwrite'].includes(key)) {
                 appConfig[key] = value;
             }
         });
@@ -446,9 +450,9 @@ window.addEventListener('DOMContentLoaded', () => {
             return;
         }
         const overwrite = document.querySelector('[name=overwrite]').value;
-        if (overwrite === 'all') {
+        if (overwrite === 'reinstall') {
             const messageDialog = document.getElementById('message-dialog');
-            messageDialog.confirm('Warning', `This will reinstall the application. Local changes will be lost.`)
+            messageDialog.confirm('Warning', `This will completely reinstall the application. Local changes will be lost.`)
             .then(
                 () => { process(false); },
                 () => { return; }

--- a/test/cypress/e2e/index.cy.js
+++ b/test/cypress/e2e/index.cy.js
@@ -143,7 +143,7 @@ describe('index page', () => {
         'method': 'POST',
         'pathname': '**/jinks/api/generator',
         'query': {
-          overwrite: 'default',
+          overwrite: 'quick',
           dry: 'true',
         }
       })
@@ -171,7 +171,7 @@ describe('index page', () => {
         'method': 'POST',
         'pathname': '**/jinks/api/generator',
         'query': {
-          overwrite: 'force',
+          overwrite: 'all',
         }
       })
         .as('e2eGenerate')
@@ -193,7 +193,7 @@ describe('index page', () => {
       cy.get('#appConfig')
         .contains('docker')
       cy.get('[name="overwrite"]')
-        .select('force')
+        .select('all')
       cy.get('#apply-config')
         .click()
       cy.wait('@e2eGenerate')


### PR DESCRIPTION
Change names of the modes to _quick_, _all_ and _reinstall_ to make it more clear what they mean.

Fix an issue if you only select base, but no other profile: the theme would not be added to the config, resulting in unstyled display. 