### PR TITLE
chore(deps): bump TEI publisher lib dependency

### DIFF
--- a/expath-pkg.xml
+++ b/expath-pkg.xml
@@ -3,7 +3,7 @@
     <title>jinks: App Manager for TEI Publisher</title>
     <dependency processor="http://exist-db.org" semver-min="6.2.0" />
     <dependency package="http://e-editiones.org/roaster" semver="1"/>
-    <dependency package="http://existsolutions.com/apps/tei-publisher-lib" semver="4"/>
+    <dependency package="http://existsolutions.com/apps/tei-publisher-lib" semver="5"/>
     <dependency package="http://tei-publisher.com/library/jinks-templates" semver="1"/>
     <dependency package="http://existsolutions.com/ns/jwt" semver="2" />
 </package>

--- a/profiles/base10/config.json
+++ b/profiles/base10/config.json
@@ -23,7 +23,7 @@
             },
             {
                 "package": "http://existsolutions.com/apps/tei-publisher-lib",
-                "semver": "4"
+                "semver": "5"
             },
             {
                 "package": "http://tei-publisher.com/library/jinks-templates",

--- a/profiles/docker/config.json
+++ b/profiles/docker/config.json
@@ -6,7 +6,7 @@
     "type": "feature",
     "docker": {
         "eXist": "6.4.0",
-        "tei-publisher-lib": "4.0.0",
+        "tei-publisher-lib": "5.0.0",
         "roaster": "1.10.0",
         "ant": "1.10.14",
         "ports": {

--- a/repo.xml
+++ b/repo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<meta xmlns="http://exist-db.org/xquery/repo"  commit-id="457bdf5938c2357a41b60c8a9bf1f4c6f2d81207" commit-time="1752504551">
+<meta xmlns="http://exist-db.org/xquery/repo"  commit-id="ad8f9e6f6b0a19b084e1457c2076a63fc8625cba" commit-time="1758270885">
     <description>jinks: an application manager (not only) for TEI Publisher</description>
     <author>Wolfgang Meier</author>
     <website>https://github.com/eeditiones/jinks</website>

--- a/test/cypress/e2e/index.cy.js
+++ b/test/cypress/e2e/index.cy.js
@@ -197,11 +197,10 @@ describe('index page', () => {
         .click()
       cy.wait('@e2eGenerate')
       cy.wait('@e2eDeploy', { responseTimeout: 40000 })
-      cy.get('.output')
-        .should('contain.text', 'Package is deployed. Visit it here', { timeout: 60000 })
-      cy.contains('Package is deployed. Visit it here', { timeout: 60000 })
+      // Assert first we have no errors. Otherwise the assert after it times out
       cy.get('.error')
-        .should('not.be.visible')
+        .should('be.empty')
+      cy.contains('Package is deployed. Visit it here', { timeout: 10000 })
     })
   })
 


### PR DESCRIPTION
Since TEI-publisher 5 is released, and CI installs the latest version, this should depend on 5 to make CI green.

Also, swap the error assert and the success one to prevent the confusing timeout we have now, but instead get something like `Expected ".error" to be empty, but instead found "BIG ERROR"`