### PR TITLE
Allow local.build.properties for ANT, exclude it for GIT and Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 .devcontainer/
 .github/
 .vscode/
+local.build.properties

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ resources/styles/pico-jinks.css
 resources/scripts/dist/
 .DS_Store
 .cursor/
+local.build.properties

--- a/build.xml
+++ b/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project default="xar" name="jinks">
     <xmlproperty file="expath-pkg.xml" />
+    <property file="local.build.properties" />
     <property name="project.version" value="${package(version)}" />
     <property name="project.app" value="${package(abbrev)}" />
     <property name="build.dir" value="build" />
@@ -8,7 +9,7 @@
     <property name="git.repo.path" value="${basedir}/.git" />
     <available file="${git.repo.path}" type="dir" property="git.present" />
 
-    <!-- Adjust path below to match location of your npm binary -->
+    <!-- Use local.build.properties file to set location of your npm binary -->
     <property name="npm" value="npm" />
 
     <!-- Only calculate git for releases -->


### PR DESCRIPTION
The `local.build.properties` file is allowed to set some properties for local environment when building package using ANT.

The `local.build.properties` file is excluded from the Docker image, so default properties are used when building the image.

Closes #160.