### PR TITLE
fix: only create commit time in repo.xml if realeas=true is set

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -53,7 +53,7 @@
     </target>
 
     <!-- TBD(DP): make conditional on release -->
-    <target name="templates" description="process template files" depends="git.revision">
+    <target name="templates" description="process template files" if="is-release">
         <echo message="Apply values to .tmpl ..." />
         <copy todir="${basedir}" overwrite="true" verbose="true">
             <fileset file="*.xml.tmpl" />
@@ -76,7 +76,7 @@
         </copy>
     </target>
 
-    <target name="git.revision" description="Store git revision in ${commit-id}" if="git.present">
+    <target name="git.revision" description="Store git revision in ${commit-id}" if="is-release" depends="check-release">
         <exec executable="git" outputproperty="git.revision" failifexecutionfails="false"
             errorproperty="">
             <arg value="--git-dir=${git.repo.path}" />


### PR DESCRIPTION
This ensures templating of repo.xml and expath-pkg.xml only takes place if release=true option (`ant -Drelease=true`) is set (usually only in CI). 

This behaviour should be applied to https://github.com/eeditiones/jinks/blob/main/profiles/base10/build.tpl.xml as well but this requires a bit more rework of the build file of the profile. 