### PR TITLE
Fix overlay issues between dropdown menu and timeline

### DIFF
--- a/profiles/theme-base10/resources/css/controls.css
+++ b/profiles/theme-base10/resources/css/controls.css
@@ -342,7 +342,8 @@ button.icon svg, .dropdown-button summary svg, [role="group"] svg, button svg, .
     border-radius: 0.5rem;
     padding: 0.5rem;
     margin: 0.5rem 0 0 0;
-    z-index: 99;
+    /* z-index value higher than elements in timeline */
+    z-index: 999;
     position: absolute;
     flex-direction: column;
     width: 100%;


### PR DESCRIPTION
Fix for this (#218):

<img width="436" height="208" alt="image" src="https://github.com/user-attachments/assets/7e81f4c7-a8f6-46c9-989e-9a97a3e052ee" />


