### PR TITLE
feat(metadata): make the presence of metadata panel optional

### DIFF
--- a/profiles/metadata-panel/config.json
+++ b/profiles/metadata-panel/config.json
@@ -13,5 +13,10 @@
         "use": [
             "templates/metadata-blocks.html"
         ]
+    },
+    "features": {
+        "metadata": {
+            "enabled": true
+        }
     }
 }

--- a/profiles/metadata-panel/doc/README.md
+++ b/profiles/metadata-panel/doc/README.md
@@ -1,6 +1,6 @@
 # Feature for metadata section in the sidebar
 
-This feature adds a basic metadata display block to the `after` layout area.
+This feature adds a basic metadata display block as a sidebar in the document view.
 
 It processes the metadata from the `teiHeader` section of the source document, according to the ODD rules, customized for the `mode` parameter set to `metadata-panel`.
 
@@ -10,10 +10,40 @@ Appropriate processing model rules are largely already contained in `teipublishe
 
 ## Configuration
 
-None for the moment. Adjustments are to be made in the ODD.
+To switch this feature off in a particular template, set the `enabled` property to `false` in the template front matter as follows:
+
+```
+<template>
+    ---json
+    {
+        "templating": {
+            "extends": "templates/pages/basic.html"
+        },
+        ...
+        "features": {
+            "metadata" : {
+                "enabled" : false
+            }
+        }
+    }
+    ---
+</template>
+```
+
+Any adjustments concerning the contents must be made in the ODD (see models with the `@predicate` `$parameters?mode='metadata-panel'`).
+
+## Layout
+
+By default, the metadata panel appears in a sidebar to the right. This behaviour is set in `templates/metadata-blocks.html`:
+```html
+<template>
+    [% template after %]
+...
+</template>
+```
 
 ## Credits
 
-This feature has been primarily funded via [Jagiellonian Digital Platform](https://labedyt.dhlab.uj.edu.pl/)
+This feature has been primarily funded by the [Jagiellonian Digital Platform](https://labedyt.dhlab.uj.edu.pl/)
 
 ![dhlab](../../../resources/images/dhlab.svg)

--- a/profiles/metadata-panel/templates/metadata-blocks.html
+++ b/profiles/metadata-panel/templates/metadata-blocks.html
@@ -1,10 +1,12 @@
 <template>
     [% template after %]
-        [% if exists($context?doc) %]
+        [% if exists($context?doc) and $context?features?metadata?enabled %]
             <div class="metadata-panel">
-                <h2><pb-i18n key="odd.metadata"/></h2>
+                <h2>
+            <pb-i18n key="odd.metadata"/>
+        </h2>
                 <pb-view src="document1" subscribe="transcription" view="single" disable-history="">
-                    <pb-param name="mode" value="metadata-panel" />
+                    <pb-param name="mode" value="metadata-panel"/>
                 </pb-view>
             </div>
         [% endif %]

--- a/schema/jinks.json
+++ b/schema/jinks.json
@@ -389,6 +389,15 @@
                         }
                     }
                 },
+                "metadata": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "If true, the metadata block will be displayed in a sidebar"
+                        }
+                    }
+                },
                 "timeline": {
                     "type": "object",
                     "properties": {


### PR DESCRIPTION
For projects that use TEI files for documentation, it’s very convenient to be able to switch off the metadata panel feature. This PR makes it optional, and updates the documentation accordingly.