### PR TITLE
feat: navigation respect text boundary

### DIFF
--- a/profiles/base10/modules/navigation-tei.xql
+++ b/profiles/base10/modules/navigation-tei.xql
@@ -140,8 +140,8 @@ declare function nav:get-subsections($config as map(*), $root as node()) {
     one must take care in the ODD to provide models for processing divs as TOC :)
 
     (: limit the TOC context to the main tei:text element, to prevent including divisions from standOff, teiHeader etc :)
-    let $headed := $root//tei:text[not(ancestor::tei:text)]//tei:div[tei:head] except $root//tei:div[tei:head]//tei:div
-    let $subsections := if (count($headed)) then $headed else $root//tei:text[not(ancestor::tei:text)]//tei:div except $root//tei:div//tei:div
+    let $headed := $root//tei:div[tei:head][ancestor::tei:text] except $root//tei:div[tei:head]//tei:div
+    let $subsections := if (count($headed)) then $headed else $root//tei:div[ancestor::tei:text] except $root//tei:div//tei:div
 
     (: respect the pagination-depth setting :)
     return $subsections/self::tei:div[count(ancestor::tei:div) < $config?depth]

--- a/profiles/base10/resources/odd/teipublisher.odd
+++ b/profiles/base10/resources/odd/teipublisher.odd
@@ -505,7 +505,7 @@
             <param name="content" value="@n"/>
             <param name="emit" value="'transcription'"/>
             <param name="subscribe" value="'transcription'"/>
-            <param name="order" value="count($get(.)/preceding::pb) + 1"/>
+            <param name="order" value="count($get(.)/preceding::pb[ancestor::text]) + 1"/>
             <param name="emit-on-load" value="'emit-on-load'"/>
             <param name="facs" value="$parameters?context-path || &#34;/&#34; || substring-after(document-uri(root($parameters?root)), $global:data-root || '/') || '/manifest.json'"/>
         </model>
@@ -518,7 +518,7 @@
             <param name="content" value="@n"/>
             <param name="emit" value="'transcription'"/>
             <param name="subscribe" value="'transcription'"/>
-            <param name="order" value="count($get(.)/preceding::pb) + 1"/>
+            <param name="order" value="count($get(.)/preceding::pb[ancestor::text]) + 1"/>
             <param name="emit-on-load" value="'emit-on-load'"/>
             <param name="facs" value="let $ref := if ($global:address-by-id)                          then                              root($parameters?root)/descendant-or-self::TEI/@xml:id                          else                              substring-after(document-uri(root($parameters?root)), $global:data-root || '/')                         return 'api/iiif/' || $ref"/>
         </model>

--- a/profiles/iiif/config.json
+++ b/profiles/iiif/config.json
@@ -27,7 +27,7 @@
         "iiif": {
             "viewer": "pb-tify",
             "base_uri": "https://apps.existsolutions.com/cantaloupe/iiif/2/",
-            "milestone_xpath": "//tei:pb",
+            "milestone_xpath": "//tei:text//tei:pb",
             "replace_facs": {
                 "regex": "^[^:]+:(.*)",
                 "replace": "$1"


### PR DESCRIPTION
- establishing navigation sections in `page` or `div` view only look within `text`; ignore any other, e.g. in standOff or teiHeader
- same for iiif manifest config
- same for establishing order in `pb-facs-link` via ODD