### PR TITLE
Hide horizontal overflow in pico-jinks styles

### DIFF
--- a/resources/styles/pico-jinks.sass
+++ b/resources/styles/pico-jinks.sass
@@ -492,6 +492,7 @@ details pb-markdown
     overflow: auto
     column-gap: 1rem
     justify-content: flex-start
+    overflow-x: hidden
 
     li
         display: flex


### PR DESCRIPTION
the app icon area was scrolling horizontally. This change fixes that.