### PR TITLE
ci: run test on exist 7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
          include:
            - exist-version: latest
              java-version: 21
-             experimental: true
+             experimental: false
            - exist-version: release
              java-version: 11
              experimental: true

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        EXIST_BASE: [6.4.0]
+        EXIST_BASE: [6.4.1]
 
     steps:
       - name: Check out repository
@@ -112,7 +112,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           build-args: |
             PUBLISHER_VERSION=main
-            EXIST_VERSION=6.4.0
+            EXIST_VERSION=6.4.1
           builder: ${{ steps.buildx.outputs.name }}
           push: true
           sbom: true


### PR DESCRIPTION
bump the container deploy to latest stable release

start testing on 7 properly after https://github.com/eeditiones/jinks/pull/302

see #107 