### PR TITLE
fix(facets): make checkboxes siblings of labels

### DIFF
--- a/profiles/base10/modules/facets.xql
+++ b/profiles/base10/modules/facets.xql
@@ -55,13 +55,17 @@ declare function facets:print-table($config as map(*), $nodes as element()+, $va
                 array:for-each(facets:sort($config, $lang, $facets), function($entry) {
                     map:for-each($entry, function($label, $freq) {
                         let $content := facets:translate($config, $lang, $label)
+                        let $name := "facet-" || $config?dimension
                         return
                         <tr>
                             <td>
-                                <label>
-                                    <input type="checkbox" class="facet" name="facet-{$config?dimension}" value="{$label}">
-                                    { if ($label = $params) then attribute checked { "checked" } else () }
-                                    </input>
+                                <input type="checkbox"
+                                    id="{$name}"
+                                    name="{$name}"
+                                    value="{$label}">
+                                { if ($label = $params) then attribute checked { "checked" } else () }
+                                </input>
+                                <label for="{$name}">
                                     <pb-i18n key="{$content}">{$content}</pb-i18n>
                                 </label>
                             </td>
@@ -87,7 +91,6 @@ declare function facets:print-table($config as map(*), $nodes as element()+, $va
         else
             ()
 };
-
 declare function facets:display($config as map(*), $nodes as element()+) {
     let $params := facets:get-parameter("facet-" || $config?dimension)
     let $lang := tokenize(facets:get-parameter("language"), '-')[1]
@@ -115,12 +118,19 @@ declare function facets:display($config as map(*), $nodes as element()+) {
                     <h3><pb-i18n key="{$config?heading}">{$config?heading}</pb-i18n>
                     {
                         if ($fcount > $max) then
-                            <label>
-                                <input type="checkbox" class="facet" name="all-{$config?dimension}">
-                                { if (facets:get-parameter("all-" || $config?dimension)) then attribute checked { "checked" } else () }
-                                </input>
+												let $name := "all-" || $config?dimension
+												return (
+                            <input type="checkbox" class="facet" name="{$name}" id="{$name}"> {
+														    if (facets:get-parameter("all-" || $config?dimension)) then
+																    attribute checked { "checked" }
+																else (
+																)
+														}
+                            </input>,
+                            <label for="{$name}">
                                 <pb-i18n key="facets.show">Show top 50</pb-i18n>
-                            </label>
+												    </label>
+											  )
                         else
                             ()
                     }
@@ -128,7 +138,7 @@ declare function facets:display($config as map(*), $nodes as element()+) {
                 else
                     ()
             }
-            
+
             {
                 $table,
                 (: if config specifies a property "source", output combo-box :)

--- a/profiles/static/static/resources/scripts/search.tps.js
+++ b/profiles/static/static/resources/scripts/search.tps.js
@@ -39,11 +39,11 @@ function kwicText(str, start, end, words = 5) {
 }
 
 /**
- * 
- * @param {*} index 
- * @param {string[]} fields 
- * @param {string} query 
- * @param {[{facet: string, value: string[]}]} facets 
+ *
+ * @param {*} index
+ * @param {string[]} fields
+ * @param {string} query
+ * @param {[{facet: string, value: string[]}]} facets
  */
 function search(index, fields, query, facets) {
     const results = document.getElementById('results');
@@ -73,7 +73,7 @@ function search(index, fields, query, facets) {
     index.searchAsync(query, 100, queryOptions).then((resultsByField) => {
         let result = [];
         resultsByField.forEach(byField => {
-            byField.result.forEach((match) => { 
+            byField.result.forEach((match) => {
                 result.push({
                     field: byField.field,
                     doc: match.doc
@@ -89,7 +89,7 @@ function search(index, fields, query, facets) {
                 return entry.doc[dimension].some((facet) => value.includes(facet.id));
             });
         });
-        
+
         const info = document.createElement('h4');
         if (result.length === 100) {
             info.innerHTML = `Showing first 100 matches.`;
@@ -181,7 +181,7 @@ function outputFacet(dimension, values, queryFacets) {
         input.addEventListener('change', function(ev) {
             searchForm.dispatchEvent(new Event('submit', { 'bubbles': true, 'cancelable': true }));
         });
-        label.appendChild(input);
+        div.appendChild(input);
         const text = document.createTextNode(value.place);
         label.appendChild(text);
         div.appendChild(label);
@@ -243,7 +243,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     });
                 }
             });
-            
+
             search(index, fields, query, facets);
         });
 


### PR DESCRIPTION
More semantic HTML. Reflects examples on
https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/checkbox better and makes HTML structure with USWDS and Bootstrap UI, among others.

While this can of course affect custom CSS, I do not expect rules to require that `label` parent.

I know that PicoCSS includes [examples](https://picocss.com/docs/forms/checkboxes) with `<label><input type="check"></label>`, but also [the proposed approach:](https://picocss.com/docs/forms/checkboxes#horizontal-stacking:~:text=%3Cinput%20type%3D%22checkbox%22%20id%3D%22hindi%22%20name%3D%22hindi%22%20checked%20/%3E%0A%20%20%3Clabel%20htmlFor%3D%22hindi%22%3EHindi%3C/label%3E): 
 ```html
  <input type="checkbox" id="hindi" name="hindi" checked />
  <label htmlFor="hindi">Hindi</label>
```