### PR TITLE
fix(seo): allow access to api endpoints for crawlers

### DIFF
--- a/profiles/sitemap/robots.tpl.txt
+++ b/profiles/sitemap/robots.tpl.txt
@@ -1,9 +1,5 @@
 User-agent: *
 
-Disallow: /api/
-Disallow: /*/api/*
-Disallow: /resources/
-Disallow: /*/resources/*
 Disallow: /transform/
 Disallow: /*/transform/*
 Disallow: /test/


### PR DESCRIPTION
Otherwise crawlers will just see pages without any content: the content comes from /api/document/XXX.xml.