### PR TITLE
feat: refactor register-map

### DIFF
--- a/profiles/base10/modules/config.xqm
+++ b/profiles/base10/modules/config.xqm
@@ -295,38 +295,7 @@ declare variable $config:data-exclude := $gen:data-exclude;
 declare variable $config:register-root := $gen:register-root;
 declare variable $config:register-forms := $config:register-root || "/templates";
 
-declare variable $config:register-map := map {
-    "person": map {
-        "id": "pb-persons",
-        "default": "person-default",
-        "prefix": "person-"
-    },
-    "place": map {
-        "id": "pb-places",
-        "default": "place-default",
-        "prefix": "place-"
-    },
-    "bibliography": map {
-        "id": "pb-bibl",
-        "default": "bibl-default",
-        "prefix": "bibl-"
-    },
-    "organization": map {
-        "id": "pb-organizations",
-        "default": "organization-default",
-        "prefix": "org-"
-    },
-    "term": map {
-        "id": "pb-keywords",
-        "default": "term-default",
-        "prefix": "category-"
-    },
-    "work": map {
-        "id": "pb-works",
-        "default": "work-default",
-        "prefix": "work-"
-    }
-};
+declare variable $config:register-map := $gen:register-map;
 
 (:~
  : The main ODD to be used by default

--- a/profiles/base10/modules/generated-config.tpl.xql
+++ b/profiles/base10/modules/generated-config.tpl.xql
@@ -47,6 +47,43 @@ declare variable $config:sort-default := "[[$features?browse?sort?default]]";
     declare variable $config:register-root := $config:data-root || "/registers";
 [% endif %]
 
+[% if map:contains($defaults, "register-map") %]
+    declare variable $config:register-map as map(*) := parse-json('[[$defaults?register-map]]');
+[% else %]
+    declare variable $config:register-map as map(*) := map {
+        "person": map {
+            "id": "pb-persons",
+            "default": "person-default",
+            "prefix": "person-"
+        },
+        "place": map {
+            "id": "pb-places",
+            "default": "place-default",
+            "prefix": "place-"
+        },
+        "bibliography": map {
+            "id": "pb-bibl",
+            "default": "bibl-default",
+            "prefix": "bibl-"
+        },
+        "organization": map {
+            "id": "pb-organizations",
+            "default": "organization-default",
+            "prefix": "org-"
+        },
+        "term": map {
+            "id": "pb-keywords",
+            "default": "term-default",
+            "prefix": "category-"
+        },
+        "work": map {
+            "id": "pb-works",
+            "default": "work-default",
+            "prefix": "work-"
+        }
+    };
+[% endif %]
+
 declare variable $config:data-exclude := (
     [[ string-join($defaults?data-exclude?*, ",&#10;    ") ]]
 );

--- a/profiles/base10/modules/odd-global.tpl.xqm
+++ b/profiles/base10/modules/odd-global.tpl.xqm
@@ -55,3 +55,9 @@ declare variable $config:register-root := $config:data-root || "/registers";
 [% else %]
     declare variable $config:address-by-id := false();
 [% endif %]
+
+(:~
+ : The map with the register IDs
+:)
+
+declare variable $config:register-map as map(*) := [% $defaults?register-map %];

--- a/profiles/base10/resources/odd/teipublisher.odd
+++ b/profiles/base10/resources/odd/teipublisher.odd
@@ -1021,7 +1021,7 @@ flex-wrap: wrap;
                     <model predicate="$parameters?display='browse' or $parameters?mode=('breadcrumb', 'toc', 'register', 'register-details')" behaviour="inline"/>
                     <model predicate="@key or @ref" behaviour="alternate" cssClass="persName context">
             <param name="default" value="."/>
-            <param name="alternate" value="let $key:= head((@key, @ref))                          let $resolved := id($key, collection($global:register-root)/id('pb-persons')) return if (count($resolved)) then $resolved else $key"/>
+            <param name="alternate" value="let $key:= head((@key, @ref))                          let $resolved := id($key, collection($global:register-root)/id($global:register-map?person?id)) return if (count($resolved)) then $resolved else $key"/>
         </model>
                     <model behaviour="inline"/>
                 </elementSpec>
@@ -1055,7 +1055,7 @@ flex-wrap: wrap;
         </model>
                     <model predicate="@key or @ref" behaviour="alternate" cssClass="persName context">
             <param name="default" value="."/>
-            <param name="alternate" value="let $key:= head((@key, @ref))                          let $resolved := id($key, collection($global:register-root)/id('pb-persons')) return if (count($resolved)) then $resolved else $key"/>
+            <param name="alternate" value="let $key:= head((@key, @ref))                          let $resolved := id($key, collection($global:register-root)/id($global:register-map?person?id)) return if (count($resolved)) then $resolved else $key"/>
         </model>
                     <model behaviour="inline"/>
                 </elementSpec>
@@ -1063,7 +1063,7 @@ flex-wrap: wrap;
                     <model output="fo" behaviour="inline"/>
                     <model output="print" behaviour="inline"/>
                     <model predicate="@key and $parameters?mode='register-details'" behaviour="inline">
-            <param name="content" value="let $key:= head((@key, @ref)) return id($key, collection($global:register-root)/id('pb-places'))/placeName[@type='main']/string()"/>
+            <param name="content" value="let $key:= head((@key, @ref)) return id($key, collection($global:register-root)/id($global:register-map?place?id))/placeName[@type='main']/string()"/>
         </model>
                     <model predicate="$parameters?display='browse' or $parameters?mode='breadcrumb' or $parameters?mode='toc'" behaviour="inline"/>
                     <model predicate="$parameters?mode='register'" behaviour="pass-through">
@@ -1083,7 +1083,7 @@ flex-wrap: wrap;
                     <model predicate="ancestor::correspContext" behaviour="inline"/>
                     <model predicate="@key or @ref" behaviour="alternate" cssClass="placeName context">
             <param name="default" value="."/>
-            <param name="alternate" value="let $key:= head((@key, @ref))                          let $resolved := id($key, collection($global:register-root)/id('pb-places')) return if (count($resolved)) then $resolved else $key"/>
+            <param name="alternate" value="let $key:= head((@key, @ref))                          let $resolved := id($key, collection($global:register-root)/id($global:register-map?place?id)) return if (count($resolved)) then $resolved else $key"/>
         </model>
                     <model behaviour="inline"/>
                 </elementSpec>
@@ -1091,7 +1091,7 @@ flex-wrap: wrap;
                     <model output="fo" behaviour="inline"/>
                     <model output="print" behaviour="inline"/>
                     <model predicate="@key and $parameters?mode='register-details'" behaviour="inline">
-            <param name="content" value="let $key:= head((@key, @ref)) return id($key, collection($global:register-root)/id('pb-organizations'))/placeName[@type='main']/string()"/>
+            <param name="content" value="let $key:= head((@key, @ref)) return id($key, collection($global:register-root)/id($global:register-map?organization?id))/placeName[@type='main']/string()"/>
         </model>
                     <model predicate="$parameters?display='browse' or $parameters?mode='breadcrumb' or $parameters?mode='toc'" behaviour="inline"/>
                     <model predicate="$parameters?mode='register'" behaviour="pass-through">
@@ -1111,7 +1111,7 @@ flex-wrap: wrap;
                     <model predicate="ancestor::correspContext" behaviour="inline"/>
                     <model predicate="@key or @ref" behaviour="alternate" cssClass="orgName context">
             <param name="default" value="."/>
-            <param name="alternate" value="let $key:= head((@key, @ref)) return id($key, collection($global:register-root)/id('pb-organizations'))"/>
+            <param name="alternate" value="let $key:= head((@key, @ref)) return id($key, collection($global:register-root)/id($global:register-map?organization?id))"/>
         </model>
                     <model behaviour="inline"/>
                 </elementSpec>

--- a/profiles/registers/config.json
+++ b/profiles/registers/config.json
@@ -50,5 +50,38 @@
         "registers": {
             "columns": 2
         }
-    }
+    },
+    "defaults": {
+        "register-map": { 
+        "person": {
+            "id": "pb-persons",
+            "default": "person-default",
+            "prefix": "person-"
+        },
+        "place":  {
+            "id": "pb-places",
+            "default": "place-default",
+            "prefix": "place-"
+        },
+        "bibliography":  {
+            "id": "pb-bibl",
+            "default": "bibl-default",
+            "prefix": "bibl-"
+        },
+        "organization":  {
+            "id": "pb-organizations",
+            "default": "organization-default",
+            "prefix": "org-"
+        },
+        "term":  {
+            "id": "pb-keywords",
+            "default": "term-default",
+            "prefix": "category-"
+        },
+        "work":  {
+            "id": "pb-works",
+            "default": "work-default",
+            "prefix": "work-"
+        }
+    }}
 }

--- a/schema/jinks.json
+++ b/schema/jinks.json
@@ -228,6 +228,27 @@
                         }
                     },
                     "description": "The fields to sort by default when displaying list of documents"
+                },
+                "register-map": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^[^\\s]+$": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                },
+                                "default": {
+                                    "type": "string"
+                                },
+                                "prefix": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": true
+                        }
+                    },
+                    "description": "Map that contains the different type of entities in the register, with their IDs and prefixes."
                 }
             }
         },


### PR DESCRIPTION
This PR:
- Adds `$config:register-map` to the defaults of `config.json` (and makes the pertinent changes in the schema)
- Adds this map to `odd-global` so that it can be accessed from the ODD (before, the IDs to the registers were hard-coded in the TEI Publisher ODD)