### PR TITLE
Layout option to fix sidebars with content-top spanning across

### DIFF
--- a/profiles/base10/templates/layouts/base.html
+++ b/profiles/base10/templates/layouts/base.html
@@ -68,7 +68,7 @@
             locale-fallback-ns="app [[ if (map:contains($context, 'i18n')) then string-join($context?i18n?*, ' ') else () ]]"
             unresolved="unresolved"
             url-template="[[ $context?urls?template ]]" url-ignore="[[ $context?urls?ignore ]]"
-            class="[[ $context?theme?layout?class ]]"
+            class="[[ string-join((tokenize($context?theme?layout?class, '\s+'), if (not($context?theme?layout?before?collapsible)) then 'before-fixed' else (), if (not($context?theme?layout?after?collapsible)) then 'after-fixed' else ()), ' ') ]]"
             require-language="require-language" theme="resources/css/components.css">
             <header class="page-header">
                 <div>

--- a/profiles/docs/templates/pages/kant.html
+++ b/profiles/docs/templates/pages/kant.html
@@ -17,6 +17,13 @@
                 "enabled": true,
                 "type": "image"
             }
+        },
+        "theme": {
+            "layout": {
+                "before": {
+                    "collapsible": false
+                }
+            }
         }
     }
     ---

--- a/profiles/docs/templates/pages/kant.html
+++ b/profiles/docs/templates/pages/kant.html
@@ -17,13 +17,6 @@
                 "enabled": true,
                 "type": "image"
             }
-        },
-        "theme": {
-            "layout": {
-                "before": {
-                    "collapsible": false
-                }
-            }
         }
     }
     ---

--- a/profiles/docs/templates/pages/tei-lex.html
+++ b/profiles/docs/templates/pages/tei-lex.html
@@ -15,6 +15,13 @@
         "urls": {
             "template": "encyclopedia/:search?",
             "ignore": "path,odd,view,userParams"
+        },
+        "theme": {
+            "layout": {
+                "before": {
+                    "collapsible": false
+                }
+            }
         }
     }
     ---

--- a/profiles/theme-base10/config.json
+++ b/profiles/theme-base10/config.json
@@ -87,11 +87,13 @@
             "max-width": "84rem",
             "search": "before-top",
             "before": {
+                "collapsible": true,
                 "hidden": false,
                 "toggle": true,
                 "width": "min(30vw, 356px)"
             },
             "after": {
+                "collapsible": true,
                 "hidden": false,
                 "toggle": true,
                 "width": "min(30vw, 356px)"

--- a/profiles/theme-base10/doc/README.md
+++ b/profiles/theme-base10/doc/README.md
@@ -33,9 +33,11 @@ The following table shows the current list of settings which can be changed via 
 | `fonts.menubar.size` | Font size for the menubar. Use `rem` for relative size. | `"14px"` |
 | `fonts.toc.size` | Font size for table of contents. Use `rem` for relative size. | `"1.125rem"` |
 | `icons` | List of icon files to include in the theme. Path should be relative to resources/css. | `[0 items]` |
+| `layout.after.collapsible` | If true, the after sidebar can be collapsed and expanded | `true` |
 | `layout.after.hidden` | If true, the after sidebar will be initially hidden | `false` |
 | `layout.after.toggle` | If true, add a toggle button to the after sidebar to collapse and expand | `true` |
 | `layout.after.width` | Width of the after sidebar | `"min(30vw, 356px)"` |
+| `layout.before.collapsible` | If true, the before sidebar can be collapsed and expanded | `true` |
 | `layout.before.hidden` | If true, the before sidebar will be initially hidden | `false` |
 | `layout.before.toggle` | If true, add a toggle button to the before sidebar to collapse and expand | `true` |
 | `layout.before.width` | Width of the before sidebar | `"min(30vw, 356px)"` |

--- a/profiles/theme-base10/resources/css/layouts.css
+++ b/profiles/theme-base10/resources/css/layouts.css
@@ -146,6 +146,59 @@
     grid-area: before-top;
 }
 
+/* Fixed before sidebar */
+.fixed-layout.before-fixed > .before-top {
+    display: none;
+}
+
+.fixed-layout.before-fixed > .before,
+.fixed-layout.before-fixed > .before-top {
+    border-right: none;
+}
+
+.fixed-layout.before-fixed > .before-top .aside-toggle {
+    display: none;
+}
+
+/* content-top should span across before-top */
+.fixed-layout.before-fixed > .content-top {
+    grid-column: before-top / content-top;
+}
+
+/* Fixed after sidebar */
+.fixed-layout.after-fixed > .after-top {
+    display: none;
+}
+
+.fixed-layout.after-fixed > .after,
+.fixed-layout.after-fixed > .after-top {
+    border-left: none;
+}
+
+.fixed-layout.after-fixed > .after-top .aside-toggle {
+    display: none;
+}
+
+/* content-top should span across after-top */
+.fixed-layout.after-fixed > .content-top {
+    grid-column: content-top / after-top;
+}
+
+/* content-top should span across before-top and after-top */
+.fixed-layout.before-fixed.after-fixed > .content-top {
+    grid-column: before-top / after-top;
+}
+
+/* before should have default background color when it is fixed */
+.fixed-layout.before-fixed >.before:not(:empty) {
+    background-color: var(--jinks-background-color);
+}
+
+/* after should have default background color when it is fixed */
+.fixed-layout.after-fixed > .after:not(:empty) {
+    background-color: var(--jinks-background-color);
+}
+
 .fixed-layout>.after-top {
     grid-area: after-top;
 }

--- a/schema/jinks.json
+++ b/schema/jinks.json
@@ -1019,6 +1019,11 @@
                         "before": {
                             "type": "object",
                             "properties": {
+                                "collapsible": {
+                                    "type": "boolean",
+                                    "description": "If true, the before sidebar can be collapsed and expanded",
+                                    "default": true
+                                },
                                 "toggle": {
                                     "type": "boolean",
                                     "description": "If true, add a toggle button to the before sidebar to collapse and expand"
@@ -1039,6 +1044,11 @@
                         "after": {
                             "type": "object",
                             "properties": {
+                                "collapsible": {
+                                    "type": "boolean",
+                                    "description": "If true, the after sidebar can be collapsed and expanded",
+                                    "default": true
+                                },
                                 "toggle": {
                                     "type": "boolean",
                                     "description": "If true, add a toggle button to the after sidebar to collapse and expand"


### PR DESCRIPTION
Adds a config option to fix one or both sidebars with breadcrumbs and toolbar spanning across.

For example, in the encyclopedia demo, the sidebar is required for the page to function:

<img width="1821" height="693" alt="image" src="https://github.com/user-attachments/assets/3f662662-2c5a-4419-a27b-2725e4cd09f7" />
