### PR TITLE
Keep profile versions, guard against breaking updates

### DIFF
--- a/modules/api.json
+++ b/modules/api.json
@@ -221,6 +221,15 @@
                             "type": "boolean",
                             "default": "false"
                         }
+                    },
+                    {
+                        "name": "confirm",
+                        "in": "query",
+                        "schema": {
+                            "type": "boolean",
+                            "default": "false"
+                        },
+                        "description": "Confirm proceeding with update despite breaking changes detected in profile versions"
                     }
                 ],
                 "requestBody": {

--- a/modules/api.xql
+++ b/modules/api.xql
@@ -39,9 +39,10 @@ declare function api:generator($request as map(*)) {
     let $config := if ($request?body instance of array(*)) then $request?body?1 else $request?body
     let $overwrite := $request?parameters?overwrite
     let $dryRun := $request?parameters?dry
+    let $confirm := $request?parameters?confirm
     let $lastModified := api:resolve-conflicts($config?config?id, $config?resolve?*)
     return
-        generator:process(map { "overwrite": $overwrite, "dry": $dryRun, "last-modified": $lastModified }, $config?config)
+        generator:process(map { "overwrite": $overwrite, "dry": $dryRun, "confirm": $confirm, "last-modified": $lastModified }, $config?config)
 };
 
 declare function api:expand-template($request as map(*)) {
@@ -344,17 +345,21 @@ declare function api:resolve-conflict($request as map(*)) {
 declare %private function api:resolve-conflicts($appId as xs:string, $paths as xs:string*) {
     let $target := path:get-package-target($appId)
     return
-        if ($target) then
+        if ($target and xmldb:collection-available($target)) then
             let $jsonPath := path:resolve-path($target, ".jinks.json")
-            let $lastModified := xmldb:last-modified(path:parent($jsonPath), path:basename($jsonPath))
-            let $json := generator:load-json($jsonPath, map {})
-            let $updated :=
-                fold-right($paths, $json, function($path, $input) {
-                    map:remove($input, $path)
-                }) => serialize(map { "method": "json", "indent": true()})
-            let $_ := xmldb:store($target, ".jinks.json", $updated, "application/json")
             return
-                $lastModified
+                if (util:binary-doc-available($jsonPath)) then
+                    let $lastModified := xmldb:last-modified(path:parent($jsonPath), path:basename($jsonPath))
+                    let $json := generator:load-json($jsonPath, map {})
+                    let $updated :=
+                        fold-right($paths, $json, function($path, $input) {
+                            map:remove($input, $path)
+                        }) => serialize(map { "method": "json", "indent": true()})
+                    let $_ := xmldb:store($target, ".jinks.json", $updated, "application/json")
+                    return
+                        $lastModified
+                else
+                    ()
         else
             ()
 };

--- a/modules/generator.xql
+++ b/modules/generator.xql
@@ -6,6 +6,7 @@ xquery version "3.1";
 module namespace generator="http://tei-publisher.com/library/generator";
 
 declare namespace repo="http://exist-db.org/xquery/repo";
+declare namespace pkg="http://expath.org/ns/pkg";
 
 import module namespace cpy="http://tei-publisher.com/library/generator/copy" at "cpy.xql";
 import module namespace inspect="http://exist-db.org/xquery/inspection";
@@ -16,6 +17,15 @@ import module namespace tmpl="http://e-editiones.org/xquery/templates";
 declare variable $generator:NAMESPACE := "http://tei-publisher.com/library/generator";
 
 declare variable $generator:ERROR_NOT_FOUND := xs:QName("generator:not-found");
+
+(:~ Jinks version - read from expath-pkg.xml :)
+declare variable $generator:JINKS_VERSION := 
+    let $pkgPath := $config:app-root || "/expath-pkg.xml"
+    return
+        if (doc-available($pkgPath)) then
+            doc($pkgPath)/pkg:package/@version/string()
+        else
+            "unknown";
 
 declare variable $generator:PROFILES_ROOT := $config:app-root || "/profiles";
 
@@ -46,24 +56,59 @@ declare function generator:profile-path($name as xs:string) {
  :)
 declare function generator:process($settings as map(*)?, $config as map(*)?) {
     let $context := generator:prepare($settings, $config)
+    let $versionCheck :=
+        if ($context?_update) then
+            let $target := path:get-package-target($context?id)
+            (: Try .jinks-versions.json first, fall back to config.json for backwards compatibility :)
+            let $versionsPath := $target || "/.jinks-versions.json"
+            let $configPath := $target || "/config.json"
+            let $installedVersions :=
+                if (util:binary-doc-available($versionsPath)) then
+                    generator:load-json($versionsPath, map {})
+                else
+                    generator:load-json($configPath, map {})
+            return generator:check-profile-versions($installedVersions, $context)
+        else
+            map { "has-breaking-changes": false() }
+    let $_ := util:log("INFO", ("Version check result - has-breaking-changes: " || $versionCheck?has-breaking-changes))
+    let $shouldProceed :=
+        (: Only proceed with update if:
+         1. Not an update (new app), OR
+         2. Confirm parameter is true, OR
+         3. No breaking changes detected
+         :)
+        not($context?_update) or
+        $settings?confirm or
+        not($versionCheck?has-breaking-changes)
     let $result :=
-        for $profileName in $context?profiles?*
-        let $adjContext := map:merge((
-            $context,
-            map {
-                "source": generator:profile-path($profileName),
-                "_noDeploy": map:contains($config, "profiles") or $settings?dry,
-                "_lastModified": $settings?last-modified
-            }
-        ))
-        return
-            generator:write($adjContext, generator:profile-path($profileName), $config)
+        if ($shouldProceed) then
+            for $profileName in $context?profiles?*
+            let $adjContext := map:merge((
+                $context,
+                map {
+                    "source": generator:profile-path($profileName),
+                    "_noDeploy": map:contains($config, "profiles") or $settings?dry,
+                    "_lastModified": $settings?last-modified
+                }
+            ))
+            return
+                generator:write($adjContext, generator:profile-path($profileName), $config)
+        else
+            ()
     let $postProcessed :=
-        for $profileName in $context?profiles?*
-        return
-            generator:after-write($context, $result, generator:profile-path($profileName))
-    let $nextStep := 
-        if (not(repo:list() = $context?id)) then
+        if ($shouldProceed) then
+            for $profileName in $context?profiles?*
+            return
+                generator:after-write($context, $result, generator:profile-path($profileName))
+        else
+            ()
+    let $nextStep :=
+        if (not($shouldProceed)) then
+            map {
+                "message": "Update blocked due to breaking changes. Set confirm=true to proceed.",
+                "action": "CONFIRM"
+            }
+        else if (not(repo:list() = $context?id)) then
             map {
                 "message": "Package is not deployed yet. Deploy it by calling /api/generator/{profile}/deploy" ,
                 "action": "DEPLOY"
@@ -77,6 +122,7 @@ declare function generator:process($settings as map(*)?, $config as map(*)?) {
         map {
             "messages": array { generator:filter-conflicts($result), $postProcessed },
             "config": $context,
+            "version-check": $versionCheck,
             "nextStep": $nextStep
         }
 };
@@ -259,17 +305,38 @@ declare %private function generator:extends($config as map(*), $profile as xs:st
         let $extendedConfig :=
             for $extProfile in $extendedProfiles
             where not($extProfile = $profile)
-            let $log := util:log("INFO", ("Loading extended profile: " || $extProfile))
-            return
-                generator:load-json(generator:profile-path($extProfile) || "/config.json", map {})
+            let $profileConfig := generator:load-json(generator:profile-path($extProfile) || "/config.json", map {})
+            let $profileVersion := ($profileConfig?version, "1.0.0")[1]
+            let $profileChanges := $profileConfig?changes
+            let $extendedProfileConfig :=
+                $profileConfig
                 => generator:extends($extProfile)
+            let $recursiveVersions := $extendedProfileConfig?profile-versions
+            let $recursiveChanges := $extendedProfileConfig?profile-changes
+            return
+                map:merge((
+                    $extendedProfileConfig,
+                    map {
+                        "profile-versions": map:merge((
+                            $recursiveVersions,
+                            map { $extProfile: $profileVersion }
+                        )),
+                        "profile-changes": map:merge((
+                            $recursiveChanges,
+                            if (exists($profileChanges)) then
+                                map { $extProfile: $profileChanges }
+                            else
+                                ()
+                        ))
+                    }
+                ))
         return
             tmpl:merge-deep((
                 $extendedConfig,
                 map {
                     "profiles": array { $extendedConfig?profiles?*, $profile }
                 },
-                map:remove($config, "extends")
+                map:remove(map:remove(map:remove($config, "extends"), "profile-versions"), "profile-changes")
             ))
     else
         map:merge((
@@ -278,6 +345,54 @@ declare %private function generator:extends($config as map(*), $profile as xs:st
                 "profiles": array { $config?profiles?*, $profile }
             }
         ))
+};
+
+(:~
+ : Compare current profile versions with installed versions and detect potential breaking changes.
+ : Returns a map with profile names that have major version bumps.
+ :)
+declare function generator:check-profile-versions($installedConfig as map(*), $newConfig as map(*)) as map(*) {
+    let $installedVersions :=
+        if (exists($installedConfig?profiles)) then
+            (: New format from .jinks-versions.json :)
+            $installedConfig?profiles
+        else if (exists($installedConfig?profile-versions)) then
+            (: Old format from config.json (backwards compatibility) :)
+            $installedConfig?profile-versions
+        else
+            (: Backwards compatibility: assume 1.0.0 for profiles array :)
+            map:merge(
+                for $profile in $installedConfig?profiles?*
+                return
+                    map { $profile: "1.0.0" }
+            )
+    let $newVersions := $newConfig?profile-versions
+    let $newChanges := $newConfig?profile-changes
+    let $breaking :=
+        map:merge(
+            map:for-each($newVersions, function($profile, $newVersion) {
+                let $installedVersion := $installedVersions($profile)
+                let $newMajor := xs:integer(tokenize($newVersion, '\.')[1])
+                let $installedMajor := if (exists($installedVersion)) then xs:integer(tokenize($installedVersion, '\.')[1]) else 0
+                let $profileChanges := $newChanges($profile)
+                let $versionChange := if (exists($profileChanges)) then $profileChanges($newVersion) else ()
+                return
+                    if (exists($installedVersion) and $newMajor > $installedMajor) then
+                        map:entry($profile, map {
+                            "installed": $installedVersion,
+                            "new": $newVersion,
+                            "changes": $versionChange
+                        })
+                    else
+                        ()
+            })
+        )
+    let $_ := util:log("INFO", ("Breaking changes detected: " || (not(empty(map:keys($breaking))))))
+    return
+        map {
+            "has-breaking-changes": not(empty(map:keys($breaking))),
+            "breaking-profiles": $breaking
+        }
 };
 
 declare function generator:load-json($path as xs:string, $default as map(*)?) {
@@ -321,20 +436,20 @@ declare %private function generator:save-config($context as map(*), $appConfig a
     if ($context?_dry or $context?type = "bootstrap") then
         ()
     else
-        let $config := map:merge(
-            map:for-each($context, function($key, $value) {
-                if (starts-with($key, "_") or $key = "source" or $key = "target") then
-                    ()
-                else
-                    map:entry($key, $value)
-            })
-        )
         let $storeConfig := map:merge((
             (: map:entry("profiles", $context?profiles), :)
             $appConfig
         ))
+        let $versionsConfig := map:merge((
+            map { "jinks": $generator:JINKS_VERSION },
+            if (exists($context?profile-versions)) then
+                map { "profiles": $context?profile-versions }
+            else
+                ()
+        ))
         return (
             xmldb:store($context?target, "config.json", serialize($storeConfig, map { "method": "json", "indent": true()}))[2],
+            xmldb:store($context?target, ".jinks-versions.json", serialize($versionsConfig, map { "method": "json", "indent": true()}))[2],
             xmldb:store($context?target, "context.json", serialize($context, map { "method": "json", "indent": true()}))[2]
         )
 };

--- a/pages/index.html
+++ b/pages/index.html
@@ -320,5 +320,34 @@
             </ul>
         </nav>
     </pb-dialog>
+    <pb-dialog id="version-check-dialog">
+        <h3 slot="title">Breaking Changes Detected</h3>
+        <p>The following profiles have major version updates that may include breaking changes:</p>
+        <section id="breaking-changes">
+            <ul></ul>
+        </section>
+        <nav slot="footer">
+            <ul>
+                <li>
+                    <button id="confirm-update" data-tooltip="Confirm and proceed with the update">
+                        <svg class="icon">
+                            <use href="#icon-refresh"></use>
+                        </svg>
+                        <span>Confirm Update</span>
+                    </button>
+                </li>
+            </ul>
+            <ul>
+                <li>
+                    <button rel="prev" aria-label="Cancel">
+                        <svg class="icon">
+                            <use href="#icon-close"></use>
+                        </svg>
+                        <span><pb-i18n key="dialogs.cancel">Cancel</pb-i18n></span>
+                    </button>
+                </li>
+            </ul>
+        </nav>
+    </pb-dialog>
     [% endtemplate %]
 </main>

--- a/resources/scripts/editor.js
+++ b/resources/scripts/editor.js
@@ -16,8 +16,10 @@ window.addEventListener('DOMContentLoaded', () => {
     // const dryRunButton = document.getElementById('dry-run');
 
     const resolveAllButton = document.getElementById('resolve-all');
+    const confirmUpdateButton = document.getElementById('confirm-update');
 
     let resolveConflicts = {};
+    let pendingConfig = null;
 
     let isProcessing = false;
 
@@ -252,7 +254,7 @@ window.addEventListener('DOMContentLoaded', () => {
         });
     }
 
-    async function process(dryRun) {
+    async function process(dryRun, confirm = false) {
         await blockUiDuringCallback(async () => {
             const result = await displaySpinnerDuringCallback(
                 `Applying configuration…`,
@@ -280,6 +282,9 @@ window.addEventListener('DOMContentLoaded', () => {
                         if (dryRun) {
                             url.searchParams.set('dry', 'true');
                         }
+                        if (confirm) {
+                            url.searchParams.set('confirm', 'true');
+                        }
                         const response = await fetch(url, {
                             method: 'POST',
                             body: JSON.stringify(params),
@@ -303,6 +308,27 @@ window.addEventListener('DOMContentLoaded', () => {
                     }
                 },
             );
+
+            // Check for breaking changes
+            if (result['version-check'] && result['version-check']['has-breaking-changes'] && result.nextStep.action === 'CONFIRM') {
+                // Store the config for re-use when confirmed
+                pendingConfig = result.config;
+
+                // Show version check dialog
+                const versionCheckDialog = document.getElementById('version-check-dialog');
+                const breakingChangesList = versionCheckDialog.querySelector('#breaking-changes ul');
+                breakingChangesList.innerHTML = '';
+
+                Object.entries(result['version-check']['breaking-profiles']).forEach(([profile, info]) => {
+                    const li = document.createElement('li');
+                    const changesHtml = info.changes ? `<br><em class="changelog">${info.changes}</em>` : '';
+                    li.innerHTML = `<strong>${profile}</strong>: ${info.installed} → ${info.new}${changesHtml}`;
+                    breakingChangesList.appendChild(li);
+                });
+
+                versionCheckDialog.openDialog();
+                return;
+            }
 
             if (result.messages) {
                 output.innerHTML = '';
@@ -997,6 +1023,13 @@ window.addEventListener('DOMContentLoaded', () => {
                 badge.innerText = 'overwrite';
             });
         }
+    });
+
+    confirmUpdateButton.addEventListener('click', (ev) => {
+        ev.preventDefault();
+        const versionCheckDialog = document.getElementById('version-check-dialog');
+        versionCheckDialog.closeDialog();
+        process(false, true);
     });
 
     editor.addEventListener('change', (e) => {

--- a/schema/jinks.json
+++ b/schema/jinks.json
@@ -39,6 +39,16 @@
             "description": "Version of this profile. Use to keep track of different upstream profile versions.",
             "default": "1.0.0"
         },
+        "changes": {
+            "type": "object",
+            "description": "Changelog mapping version numbers to descriptions of what changed.",
+            "patternProperties": {
+                "^\\d+\\.\\d+\\.\\d+$": {
+                    "type": "string",
+                    "description": "Description of changes in this version"
+                }
+            }
+        },
         "extends": {
             "type": "array",
             "items": {

--- a/test/cypress/e2e/profile-versions.cy.js
+++ b/test/cypress/e2e/profile-versions.cy.js
@@ -1,0 +1,89 @@
+describe('profile version tracking', () => {
+  Cypress.on('uncaught:exception', (err, runnable) => {
+    return false
+  })
+
+  beforeEach(() => {
+    cy.loginApi()
+    cy.visit('/')
+  })
+
+  describe('breaking changes detection [side-effects]', () => {
+    after(() => {
+      const appUri1 = 'https://e-editiones.org/apps/e2eversiontest1'
+      cy.request({
+        method: 'GET',
+        url: `http://localhost:8080/exist/rest/db`,
+        auth: { user: 'admin', pass: '' },
+        qs: { _query: `repo:undeploy('${appUri1}'), repo:remove('${appUri1}')`, _wrap: 'no' },
+        failOnStatusCode: false
+      })
+    })
+
+    it('should warn about breaking changes and allow confirmation', () => {
+      const testAppAbbrev = 'e2eversiontest1'
+
+      cy.intercept({ method: 'POST', pathname: '**/jinks/api/generator' }).as('generate')
+
+      // Step 1: Create app with upload profile (v1.0.0)
+      cy.get('[name="abbrev"]').type(`${testAppAbbrev}{enter}`)
+      cy.get('[name="label"]').type('Version Test App')
+      cy.get('nav.tabs > ul > li > a[href="#profiles"]').click()
+      cy.get('section[data-tab="profiles"]').should('be.visible')
+      cy.get('[type="checkbox"][name="feature"]').check('upload')
+      cy.get('nav.tabs > ul > li > a[href="#config"]').click()
+      cy.get('footer .apply-config').click()
+      cy.wait('@generate', { responseTimeout: 60000 })
+      cy.contains('Package is deployed. Visit it here', { timeout: 30000 })
+
+      // Verify jinks version is recorded in .jinks-versions.json
+      cy.request({
+        method: 'GET',
+        url: `http://localhost:8080/exist/rest/db`,
+        auth: { user: 'admin', pass: '' },
+        qs: {
+          _query: `json-doc('/db/apps/${testAppAbbrev}/.jinks-versions.json')?jinks`,
+          _wrap: 'no'
+        }
+      }).then((response) => {
+        expect(response.body).to.match(/^\d+\.\d+\.\d+$/)
+      })
+
+      // Step 2: Downgrade recorded profile version to simulate older app
+      cy.request({
+        method: 'GET',
+        url: `http://localhost:8080/exist/rest/db`,
+        auth: { user: 'admin', pass: '' },
+        qs: {
+          _query: `let $c := json-doc('/db/apps/${testAppAbbrev}/.jinks-versions.json') return xmldb:store('/db/apps/${testAppAbbrev}', '.jinks-versions.json', serialize(map:merge(($c, map { 'profiles': map { 'upload': '0.0.1' } })), map { 'method': 'json' }))`,
+          _wrap: 'no'
+        }
+      })
+
+      // Step 3: Update should show warning (0.0.1 -> x.x.x)
+      cy.intercept({ method: 'POST', pathname: '**/jinks/api/generator' }).as('update')
+      cy.reload()
+      cy.get('.installed li').contains('Version Test App').click()
+      cy.get('footer .apply-config').click()
+      cy.wait('@update')
+      cy.get('#version-check-dialog', { timeout: 10000 }).should('be.visible')
+      cy.get('#breaking-changes').should('contain', 'upload')
+      cy.get('#breaking-changes').should('contain', '0.0.1')
+
+      // Step 4: Confirm update
+      cy.intercept({ method: 'POST', pathname: '**/jinks/api/generator' }).as('confirmUpdate')
+      cy.get('#confirm-update').click()
+      cy.wait('@confirmUpdate', { responseTimeout: 60000 })
+      cy.contains('Update completed.', { timeout: 30000 })
+
+      // Step 5: Second update should not warn
+      cy.intercept({ method: 'POST', pathname: '**/jinks/api/generator' }).as('secondUpdate')
+      cy.reload()
+      cy.get('.installed li').contains('Version Test App').click()
+      cy.get('footer .apply-config').click()
+      cy.wait('@secondUpdate', { responseTimeout: 60000 })
+    //   cy.get('#version-check-dialog').should('not.exist')
+      cy.contains('Update completed.', { timeout: 30000 })
+    })
+  })
+})


### PR DESCRIPTION
Profiles may come with breaking changes and users should be guarded against unintentionally updating an app.

* the version for each profile installed at generation time is now stored in `.jinks-versions.json`
* app updates will be prevented if a profile has a higher major version than the one in the app -> breaking change
* user needs to confirm the update in this case
* short change log can be stored in `config.json` and is displayed in confirmation dialog 