### PR TITLE
Fix dependency management

### DIFF
--- a/expath-pkg.xml
+++ b/expath-pkg.xml
@@ -3,8 +3,8 @@
     <title>jinks: App Manager for TEI Publisher</title>
     <dependency processor="http://exist-db.org" semver-min="6.2.0" />
     <dependency package="http://e-editiones.org/roaster" semver="1"/>
-    <dependency package="http://existsolutions.com/apps/tei-publisher-lib" semver="6"/>
-    <dependency package="http://tei-publisher.com/library/jinks-templates" semver="1"/>
+    <dependency package="http://existsolutions.com/apps/tei-publisher-lib" semver-min="6.1" semver-max="6"/>
+    <dependency package="http://tei-publisher.com/library/jinks-templates" semver-min="1.4.1" semver-max="1"/>
     <dependency package="http://existsolutions.com/ns/jwt" semver="2" />
     <xquery>
         <namespace>http://tei-publisher.com/jinks/path</namespace>

--- a/profiles/base10/config.json
+++ b/profiles/base10/config.json
@@ -24,7 +24,8 @@
             },
             {
                 "package": "http://existsolutions.com/apps/tei-publisher-lib",
-                "semver": "6"
+                "semver-min": "6.1",
+                "semver-max": "6"
             },
             {
                 "package": "http://tei-publisher.com/library/jinks-templates",

--- a/profiles/base10/expath-pkg.tpl.xml
+++ b/profiles/base10/expath-pkg.tpl.xml
@@ -1,8 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<package xmlns="http://expath.org/ns/pkg" name="[[$id]]" abbrev="[[$pkg?abbrev]]" version="[[$pkg?version]]" spec="1.0">
+<package
+    xmlns="http://expath.org/ns/pkg"
+    name="[[$id]]"
+    abbrev="[[$pkg?abbrev]]"
+    version="[[$pkg?version]]"
+    spec="1.0"
+>
     <title>[[ head(($pkg?title, $label)) ]]</title>
     <dependency processor="http://exist-db.org" semver-min="6.2.0" />
     [% for $dep in $pkg?dependencies?* %]
-        <dependency package="[[$dep?package]]" semver="[[$dep?semver]]"/>
+        <dependency
+            package="[[$dep?package]]" 
+            semver="![[$dep?semver]]"
+            semver-min="![[$dep?semver-min]]"
+            semver-max="![[$dep?semver-max]]"
+        />
     [% endfor %]
 </package>

--- a/profiles/new-profile/expath-pkg.tpl.xml
+++ b/profiles/new-profile/expath-pkg.tpl.xml
@@ -1,8 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<package xmlns="http://expath.org/ns/pkg" name="[[$id]]" abbrev="[[$pkg?abbrev]]" version="[[$pkg?version]]" spec="1.0">
+<package
+    xmlns="http://expath.org/ns/pkg"
+    name="[[$id]]"
+    abbrev="[[$pkg?abbrev]]"
+    version="[[$pkg?version]]"
+    spec="1.0"
+    >
     <title>[[ head(($pkg?title, $label)) ]]</title>
     <dependency processor="http://exist-db.org" semver-min="6.2.0" />
     [% for $dep in $pkg?dependencies?* %]
-        <dependency package="[[$dep?package]]" semver="[[$dep?semver]]"/>
+    <dependency
+        package="[[$dep?package]]" 
+        semver="![[$dep?semver]]"
+        semver-min="![[$dep?semver-min]]"
+        semver-max="![[$dep?semver-max]]"
+        />
     [% endfor %]
 </package>


### PR DESCRIPTION
Make sure generated apps will depend on newer version of tei-publisher-lib

In order to allow minimum versions the expath.pkg template had to be improved and now uses the new conditional attribute feature introduced in jinks-templates 1.4.1

refs #356 

Note: This should have been caught in CI but since it uses a provisioned jinks image with the newer versions already in it does not show there.
 