### PR TITLE
Add language attribute to html tag

### DIFF
--- a/profiles/base10/templates/layouts/base.html
+++ b/profiles/base10/templates/layouts/base.html
@@ -1,4 +1,4 @@
-<html>
+<html lang="[[page:resolve-language($context)]]">
     <head>
         [% if $context?defaults?base %]
         <base href="[[ $context-path ]]/[[ $context?defaults?base ]]"/>


### PR DESCRIPTION
Add language attribute to the html tag in base layout to satisfy WCAG Success Criterion 3.1.1