### PR TITLE
fix: pages:get-content() fails after search in multi-panel views 

### DIFF
--- a/profiles/base10/modules/lib/api/document.xql
+++ b/profiles/base10/modules/lib/api/document.xql
@@ -554,6 +554,8 @@ declare function dapi:get-fragment($request as map(*), $docs as node()*, $path a
                     query:expand($xml?config, $mapped)[1]
                 else
                     $mapped
+            (: TODO perhaps find a way to assess whether not running the query is viable or not :)
+            let $data := if ($data) then $data else $mapped
             let $content :=
                 if (not($view = "single")) then
                     pages:get-content($xml?config, $data)


### PR DESCRIPTION
With @eduarddrenth

With multi-panels views that depend on `@map`, `pages:get-content()` fails after a search for every panel in which the query returns no results.

