### PR TITLE
Bugfix/annotate pagination

### DIFF
--- a/profiles/annotate/resources/scripts/annotations/annotations.js
+++ b/profiles/annotate/resources/scripts/annotations/annotations.js
@@ -141,14 +141,22 @@ document.addEventListener("pb-page-loaded", () => {
 				const annotations = JSON.parse(ranges);
 				if (annotations.length > 0) {
 					const params = new URL(document.location).searchParams;
+					const sessionKey = `tei-publisher.annotations.session.${doc.path}`;
 					if (params.has("apply")) {
 						restoreAnnotations(doc, annotations);
+					} else if (window.sessionStorage.getItem(sessionKey)) {
+						// in-session navigation: view.annotations already has the current state
 					} else {
 						document
 							.getElementById("restore-dialog")
 							.confirm()
 							.then(() => {
+								window.sessionStorage.setItem(sessionKey, "1");
 								restoreAnnotations(doc, annotations);
+							})
+							.catch(() => {
+								// User declined restore for this session; avoid re-prompting.
+								window.sessionStorage.setItem(sessionKey, "0");
 							});
 					}
 				}
@@ -969,6 +977,7 @@ document.addEventListener("pb-page-loaded", () => {
 	window.pbEvents.subscribe("pb-annotations-changed", "transcription", (ev) => {
 		const doc = view.getDocument();
 		if (doc && doc.path) {
+			window.sessionStorage.setItem(`tei-publisher.annotations.session.${doc.path}`, "1");
 			window.localStorage.setItem(
 				`tei-publisher.annotations.${doc.path}`,
 				JSON.stringify(ev.detail.ranges),

--- a/profiles/base10/modules/lib/api.tpl.json
+++ b/profiles/base10/modules/lib/api.tpl.json
@@ -1624,6 +1624,16 @@
 						"description": "should returned HTML be wrapped into a div?"
 					},
 					{
+						"name": "user.track-ids",
+						"in": "query",
+						"schema": {
+							"type": "string",
+							"default": "no",
+							"enum": ["yes", "no"]
+						},
+						"description": "passed by the annotation editor to track IDs in the HTML"
+					},
+					{
 						"name": "If-Modified-Since",
 						"in": "header",
 						"schema": {
@@ -3050,7 +3060,7 @@
                 "x-constraints": {
                     "group": ["tei"]
                 },
-                
+
                 "requestBody": {
                     "content": {
                         "application/xml": {
@@ -3090,7 +3100,7 @@
                 "description": "Get the XML fragment for a given register entry. Used by the registry forms in the annotation editor.",
                 "tags": ["register"],
                 "operationId": "rapi:entry",
-                
+
                 "parameters": [
                     {
                         "name": "id",
@@ -3098,7 +3108,7 @@
                         "required": true,
                         "schema": {
                             "type": "string",
-                            "example": "gnd-139890289" 
+                            "example": "gnd-139890289"
                         }
                     },
                     {
@@ -3167,7 +3177,7 @@
                     }
                 }
             },
-        
+
             "put": {
                 "summary": "Save a register entry",
                 "description": "Replace an entry with the current version from the editor",
@@ -3176,7 +3186,7 @@
                 "x-constraints": {
                     "group": ["tei"]
                 },
-                
+
                 "requestBody": {
                     "content": {
                         "application/xml": {
@@ -3227,7 +3237,7 @@
                 "description": "Get the HTML fragment for a given register entry. May be used when retrieving e.g. registry content for popups asynchronously",
                 "tags": ["register"],
                 "operationId": "rapi:html",
-                
+
                 "parameters": [
                     {
                         "name": "id",
@@ -3235,7 +3245,7 @@
                         "required": true,
                         "schema": {
                             "type": "string",
-                            "example": "gnd-139890289" 
+                            "example": "gnd-139890289"
                         }
                     },
                     {

--- a/profiles/base10/modules/lib/api/document.xql
+++ b/profiles/base10/modules/lib/api/document.xql
@@ -534,6 +534,14 @@ declare function dapi:get-fragment($request as map(*), $docs as node()*, $path a
                     ()
         else
             pages:load-xml($docs, $view, $request?parameters?root, $path)
+    let $xml :=
+        if ($request?parameters?user.track-ids = "yes") then
+            for $item in $xml
+            return map:merge(($item, map {
+                "config": map:merge(($item?config, map { "depth": 1, "fill": -1 }), map { "duplicates": "use-last" })
+            }), map { "duplicates": "use-last" })
+        else
+            $xml
     return
         if ($xml?data) then
             let $userParams :=
@@ -678,7 +686,7 @@ declare function dapi:table-of-contents($request as map(*)) {
                 let $xml := pages:load-xml($documents, $request?parameters?view, (), $doc)
                 return
                     if (exists($xml)) then
-                        let $mapped := 
+                        let $mapped :=
                             if (exists($request?parameters?map)) then
                                 let $mapFun := function-lookup(xs:QName("mapping:" || $request?parameters?map), 2)
                                 return
@@ -723,13 +731,13 @@ declare %private function dapi:toc-div($node, $model as map(*), $target as xs:st
             let $hasDivs := exists(nav:get-subsections($model?config, $div))
             let $nodeId :=  if ($parent) then util:node-id($parent) else util:node-id($root)
             let $xmlId := if ($parent) then $parent/@xml:id else $root/@xml:id
-            let $hash := 
+            let $hash :=
                 if ($view != 'page' and not(nav:get-section-for-node($model?config, $div) is $root)) then
-                    if ($root/@xml:id) then 
+                    if ($root/@xml:id) then
                         attribute hash { $root/@xml:id }
                     else
                         attribute hash { util:node-id($root) }
-                else 
+                else
                     ()
             return
                     <li>


### PR DESCRIPTION
Annotations won't work if a section is partially filled up by TEI Publisher. **Always** set depth = 1 and fill = -1 if a fragment is requested by the annotation editor. This ensures we're editing physical top-level sections, not constructed fragments.