### PR TITLE
refactor blueprints

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -127,10 +127,16 @@
             <fieldset>
                 <legend>Blueprints</legend>
                 <ul>
+                    <li>
+                        <label data-tooltip="Build from base, features and theme only" data-placement="right">
+                            <input type="radio" name="blueprint" value="" checked="" data-depends="[]" />
+                            <span>None</span>
+                        </label>
+                    </li>
                     [% for $profile in filter($context?profiles, function($p) { $p?type = "blueprint"}) %]
                     <li>
                         <label data-tooltip="[[ $profile?description ]]" data-placement="right">
-                            <input type="checkbox" name="blueprint" value="[[ $profile?path ]]"
+                            <input type="radio" name="blueprint" value="[[ $profile?path ]]"
                                 data-depends="[[ serialize($profile?depends, map { 'method': 'json'}) ]]" />
                             <span>[[ $profile?label ]] <small>[[ $profile?version ]]</small></span>
                         </label>

--- a/profiles/ci/doc/README.md
+++ b/profiles/ci/doc/README.md
@@ -76,7 +76,7 @@ The CI workflows automatically handle authentication for private XAR packages:
 
 ## Default Behavior
 
-- All blueprints (docs, serafin, playground, workbench) include CI by default
+- All blueprints (docs, serafin, workbench) include CI by default
 - CI runs on every push to any branch
 - CI runs on pull/merge requests targeting `main` or `master` branches
 - Only one provider's files are generated at a time (GitHub Actions OR GitLab CI, not both)

--- a/profiles/docs/config.json
+++ b/profiles/docs/config.json
@@ -23,14 +23,23 @@
         "demo-data",
         "docker",
         "ci",
-        "landing-page"
+        "landing-page",
+        "upload"
     ],
+    "theme": {
+        "colors": {
+            "palette": "beige"
+        }
+    },
     "pkg": {
         "abbrev": "tei-publisher-docs"
     },
     "features": {
         "browse": {
             "read-only": false
+        },
+        "toc": {
+            "enabled": true
         },
         "upload": {
             "enabled": true,

--- a/profiles/playground-blueprint/config.json
+++ b/profiles/playground-blueprint/config.json
@@ -1,0 +1,32 @@
+{
+    "$schema": "../../schema/jinks.json",
+    "type": "blueprint",
+    "id": "https://e-editiones.org/apps/playground-blueprint",
+    "label": "Playground",
+    "description": "Sandbox environment for experimentation and learning",
+    "version": "1.0.0",
+    "order": 100,
+    "depends": [
+        "base10",
+        "playground",
+        "demo-data",
+        "upload"
+    ],
+    "defaults": {
+        "data-default": "playground",
+        "template": "basic.html"
+    },
+    "features": {
+        "toc": {
+            "enabled": true
+        },
+        "upload": {
+            "enabled": true
+        }
+    },
+    "theme": {
+        "colors": {
+            "palette": "beige"
+        }
+    }
+}

--- a/profiles/playground-blueprint/doc/README.md
+++ b/profiles/playground-blueprint/doc/README.md
@@ -1,0 +1,5 @@
+# Playground Blueprint
+
+A thin sandbox application built on the [Playground](../playground) feature plus demo data and upload.
+
+Use this when you want a ready-made experiment environment. To add the same ODD tooling to another app, select the Playground feature under Workflow Support instead.

--- a/profiles/playground/config.json
+++ b/profiles/playground/config.json
@@ -1,35 +1,18 @@
 {
     "$schema": "../../schema/jinks.json",
-    "type": "blueprint",
+    "type": "feature",
+    "category": "workflow",
     "id": "https://e-editiones.org/app/tei-publisher/playground",
     "label": "Playground",
-    "description": "Sandbox environment for experimentation and learning",
+    "description": "Adds ODD selection, ODD management, and experiment prompts to the browse view",
     "version": "1.0.0",
-    "depends": [
-        "base10",
-        "demo-data",
-        "upload",
-        "ci"
-    ],
     "order": 100,
-    "defaults": {
-        "data-default": "playground",
-        "template": "basic.html"
-    },
+    "depends": [
+        "base10"
+    ],
     "features": {
         "playground": {
             "enabled": true
-        },
-        "toc": {
-            "enabled": true
-        },
-        "upload": {
-            "enabled": true
-        }
-    },
-    "theme": {
-        "colors": {
-            "palette": "beige"
         }
     },
     "generator": {

--- a/profiles/playground/doc/README.md
+++ b/profiles/playground/doc/README.md
@@ -1,0 +1,11 @@
+# Playground
+
+Adds a small “playground” workflow to the browse view:
+
+* an ODD selector in the toolbar
+* an ODD manager on the browse page
+* a short login / read-only prompt for experimenting with files and ODDs
+
+Enable it by selecting the **Playground** feature under Workflow Support, or use the thin **Playground** blueprint, which also includes demo data and upload.
+
+Set `features.playground.enabled` to `true` (the feature does this by default).

--- a/resources/scripts/editor.js
+++ b/resources/scripts/editor.js
@@ -23,6 +23,8 @@ window.addEventListener('DOMContentLoaded', () => {
     let pendingConfig = null;
     /** @type {{ abbrev: string, id: string } | null} Locked package identity while an installed app is selected */
     let installedIdentity = null;
+    /** Currently selected blueprint radio (for clearing deps when switching) */
+    let selectedBlueprint = form.querySelector('[name="blueprint"]:checked');
 
     let isProcessing = false;
 
@@ -180,8 +182,11 @@ window.addEventListener('DOMContentLoaded', () => {
         form.querySelectorAll('[name="base"]').forEach((input) => {
             input.checked = extendsList.includes(input.value);
         });
-        form.querySelectorAll('[name="feature"],[name="blueprint"],[name="theme"]').forEach((input) => {
+        form.querySelectorAll('[name="feature"],[name="theme"]').forEach((input) => {
             input.checked = extendsList.includes(input.value);
+        });
+        form.querySelectorAll('[name="blueprint"]').forEach((input) => {
+            input.checked = Boolean(input.value) && extendsList.includes(input.value);
         });
 
         // Radios require a selection; fall back if the config names no known base profile
@@ -192,6 +197,13 @@ window.addEventListener('DOMContentLoaded', () => {
                 fallback.checked = true;
             }
         }
+        if (!form.querySelector('[name="blueprint"]:checked')) {
+            const none = form.querySelector('[name="blueprint"][value=""]');
+            if (none) {
+                none.checked = true;
+            }
+        }
+        selectedBlueprint = form.querySelector('[name="blueprint"]:checked');
 
         filterProfilesByBaseProfile();
         updateColorPaletteSelection(config);
@@ -839,7 +851,7 @@ window.addEventListener('DOMContentLoaded', () => {
         const extend = formData.getAll('base')
             .concat(formData.getAll('feature'))
             .concat(formData.getAll('theme'))
-            .concat(formData.getAll('blueprint'));
+            .concat(formData.getAll('blueprint').filter(Boolean));
         const sortedExtends = extend.sort((a, b) => {
             const orderA = appOrder[a];
             const orderB = appOrder[b];
@@ -890,11 +902,17 @@ window.addEventListener('DOMContentLoaded', () => {
         const selectedBase = form.querySelector('input[type="radio"][name="base"]:checked');
         const baseProfileValue = selectedBase.value;
 
-        // Get all feature, blueprint, and theme checkboxes
-        const profileCheckboxes = form.querySelectorAll('input[type="checkbox"][name="feature"], input[type="checkbox"][name="blueprint"], input[type="checkbox"][name="theme"]');
+        // Feature/theme checkboxes plus blueprint radios (excluding the empty "None" option)
+        const profileCheckboxes = form.querySelectorAll('input[type="checkbox"][name="feature"], input[type="checkbox"][name="theme"], input[name="blueprint"]');
 
         const bootstrapCheckbox = form.querySelector('input[type="checkbox"][name="bootstrap"]:checked');
         profileCheckboxes.forEach((checkbox) => {
+            // "None" blueprint option has an empty value and must stay selectable
+            if (checkbox.name === 'blueprint' && checkbox.value === '') {
+                checkbox.disabled = false;
+                return;
+            }
+
             if (bootstrapCheckbox) {
                 // When bootstrapping a new profile, allow all profiles to be selected
                 checkbox.disabled = false;
@@ -948,15 +966,31 @@ window.addEventListener('DOMContentLoaded', () => {
                 }
             }
         });
+
+        // If the selected blueprint was disabled/unchecked, fall back to None
+        if (!form.querySelector('[name="blueprint"]:checked')) {
+            const none = form.querySelector('[name="blueprint"][value=""]');
+            if (none) {
+                none.checked = true;
+            }
+        }
+        selectedBlueprint = form.querySelector('[name="blueprint"]:checked');
     }
 
     function toggleFeature(eventOrControl) {
         const target = eventOrControl.target || eventOrControl;
-        const configExtends = JSON.parse(target.dataset.depends);
+        const configExtends = JSON.parse(target.dataset.depends || '[]');
         if (configExtends) {
             configExtends.forEach((profile) => {
                 const input = form.querySelector(`[value="${profile}"]`);
+                if (!input) {
+                    return;
+                }
                 if (!target.checked && input.name === 'base') {
+                    return;
+                }
+                // Never flip another blueprint radio while resolving depends
+                if (input.name === 'blueprint' && input !== target) {
                     return;
                 }
                 input.checked = target.checked;
@@ -964,6 +998,35 @@ window.addEventListener('DOMContentLoaded', () => {
             });
         }
         update();
+    }
+
+    /**
+     * Blueprints are exclusive radios. When switching, clear the previous blueprint's
+     * dependency tree first so leftover features from the old selection are not kept.
+     */
+    function toggleBlueprint(ev) {
+        const target = ev.target;
+        const nextDepends = new Set(JSON.parse(target.dataset.depends || '[]'));
+        if (selectedBlueprint && selectedBlueprint !== target && selectedBlueprint.value) {
+            const previousDepends = JSON.parse(selectedBlueprint.dataset.depends || '[]');
+            previousDepends.forEach((profile) => {
+                if (nextDepends.has(profile)) {
+                    return;
+                }
+                const input = form.querySelector(`[value="${profile}"]`);
+                if (!input || input.name === 'base' || input.name === 'blueprint') {
+                    return;
+                }
+                input.checked = false;
+                toggleFeature(input);
+            });
+        }
+        selectedBlueprint = target;
+        if (target.value) {
+            toggleFeature(target);
+        } else {
+            update();
+        }
     }
 
     function reset(updateEditor = true) {
@@ -976,6 +1039,7 @@ window.addEventListener('DOMContentLoaded', () => {
 
         form.reset();
         form.querySelector('[name="theme"]').checked = true;
+        selectedBlueprint = form.querySelector('[name="blueprint"]:checked');
         // Filter profiles based on selected base profile (default will be first base profile)
         filterProfilesByBaseProfile();
         update(updateEditor);
@@ -1057,7 +1121,7 @@ window.addEventListener('DOMContentLoaded', () => {
         toggleFeature(ev);
         loadColorPalettes();
     }));
-    form.querySelectorAll('input[type="checkbox"][name="blueprint"]').forEach((control) => control.addEventListener('change', toggleFeature));
+    form.querySelectorAll('input[type="radio"][name="blueprint"]').forEach((control) => control.addEventListener('change', toggleBlueprint));
     form.querySelectorAll('input[type="checkbox"][name="bootstrap"]').forEach((control) => control.addEventListener('change', toggleFeature));
 
     document.getElementById('reset').addEventListener('click', (ev) => {


### PR DESCRIPTION
* mixing multiple blueprints causes confusion
* blueprints should provide a config for one specific, functionally complete app
* change UI to allow selection of only one blueprint
* split playground into feature and config-only blueprint