### PR TITLE
Fix content column being squeezed on mobile by a phantom before/after grid track

### DIFF
--- a/profiles/theme-base10/resources/css/layouts.css
+++ b/profiles/theme-base10/resources/css/layouts.css
@@ -382,6 +382,17 @@
     .fixed-layout > .after.hidden-mobile {
         display: none !important;
     }
+
+    /* The desktop zero-out rules above only match .hidden: a panel hidden on mobile via
+       .hidden-mobile keeps its grid column reserved at full width, squeezing the content
+       column even though the panel itself is invisible. Zero out the track here too. */
+    .fixed-layout:has(> .before.hidden-mobile) {
+        --jinks-layout-before-track: 0;
+    }
+
+    .fixed-layout:has(> .after.hidden-mobile) {
+        --jinks-layout-after-track: 0;
+    }
 }
 @media (min-width: 1024px) {
     .mobile,


### PR DESCRIPTION
Fixes #378.

## Problem

The grid-track zero-out rules for `.before`/`.after` in `profiles/theme-base10/resources/css/layouts.css` only match the `.hidden` class (the desktop toggle state):

```css
.fixed-layout:has(> .before.hidden):not(:has(> .before-top .aside-toggle)) {
    --jinks-layout-before-track: 0;
}
.fixed-layout:has(> .after.hidden):not(:has(> .after-top .aside-toggle)) {
    --jinks-layout-after-track: 0;
}
```

On mobile (`max-width: 1023px`), panels are hidden via a separate `.hidden-mobile` class instead, which these selectors never match. So any app that shows `.before`/`.after` by default on desktop and relies on the responsive breakpoint alone to collapse it on mobile keeps that panel's full grid column reserved (`min(30vw, 356px)` by default) even though the panel is `display: none` — squeezing the content column by exactly that width.

## This is the theme's own default, not an edge case

`templates/layouts/base.html` applies both classes unconditionally, for every app:

```html
<aside class="after hidden-mobile [[ if ($context?theme?layout?after?hidden) then 'hidden' else '' ]] ...">
```

`hidden-mobile` is always present; `.hidden` only appears when an app explicitly sets `theme.layout.after.hidden: true` (the "always-collapsed, toggle-only" desktop configuration). `theme-base10`'s own `config.json` ships `"after": { "hidden": false, ... }` as the default — i.e. the stock, out-of-the-box configuration is exactly the one that hits this bug. The only other profile in this repo that touches `layout.after` (`serafin`) overrides `mode` but not `hidden`, so it inherits the same vulnerable default. Same pattern applies symmetrically to `.before` at line 107 of `base.html`.

## Fix

Add analogous zero-out rules for `.hidden-mobile`, scoped inside the existing `@media (max-width: 1023px)` block, mirroring the desktop `.hidden` rules:

```css
.fixed-layout:has(> .before.hidden-mobile) {
    --jinks-layout-before-track: 0;
}
.fixed-layout:has(> .after.hidden-mobile) {
    --jinks-layout-after-track: 0;
}
```

## Testing

Verified against a live TEI Publisher app on `theme-base10` with an `.after` panel (tabs) visible on desktop and `hidden-mobile` at narrow viewports. Before the fix, Chrome's device toolbar at 400px width showed the content column squeezed to ~35 characters per line; after applying the equivalent rule, the content column correctly expands to the full viewport width once the panel is hidden.

Did not add the `:not(:has(> .after-top .aside-toggle))` exception from the desktop rule, since the mobile footer's aside-toggle affordance is a separate UI element (`footer.mobile-footer .aside-toggle`), not `.after-top`/`.before-top` — happy to adjust if that's wrong for some app configuration I'm not seeing.
