### PR TITLE
odd-based TOC feature

### DIFF
--- a/profiles/base10/resources/odd/teipublisher.odd
+++ b/profiles/base10/resources/odd/teipublisher.odd
@@ -100,13 +100,19 @@
                     <model behaviour="inline"/>
                 </elementSpec>
                 <elementSpec ident="app" mode="add">
-                    <model predicate="$parameters?mode=('toc', 'breadcrumb')" behaviour="inline">
-                        <param name="content" value="lem"/>
+                    <model predicate="$parameters?mode=('toc', 'breadcrumb')" behaviour="pass-through">
+                        <param name="content" value="head((lem, rdg))"/>
                     </model>
                     <model behaviour="alternate">
                         <param name="default" value="lem"/>
                         <param name="alternate" value="rdg"/>
                     </model>
+                </elementSpec>
+                <elementSpec ident="rdg" mode="add">
+                    <model predicate="$parameters?mode=('toc', 'breadcrumb')" behaviour="pass-through"/>
+                </elementSpec>
+                <elementSpec ident="lem" mode="add">
+                    <model predicate="$parameters?mode=('toc', 'breadcrumb')" behaviour="pass-through"/>
                 </elementSpec>
                 <elementSpec ident="anchor" mode="change">
                     <model predicate="$parameters?mode=('toc', 'breadcrumb')" behaviour="omit"/>
@@ -140,9 +146,11 @@
                     <model behaviour="inline"/>
                 </elementSpec>
                 <elementSpec ident="back" mode="change">
+                    <model predicate="$parameters?mode='toc'" behaviour="list"/>
                     <model behaviour="block"/>
                 </elementSpec>
                 <elementSpec ident="body" mode="change">
+                    <model predicate="$parameters?mode='toc'" behaviour="list"/>
                     <modelSequence>
             <model behaviour="index">
                 <param name="type" value="'toc'"/>
@@ -170,6 +178,7 @@
         </model>
                 </elementSpec>
                 <elementSpec ident="cb" mode="change">
+                    <model predicate="$parameters?mode='toc'" behaviour="omit"/>
                     <model behaviour="break">
             <param name="type" value="'column'"/>
             <param name="label" value="@n"/>
@@ -284,6 +293,17 @@
         </model>
                 </elementSpec>
                 <elementSpec ident="div" mode="change">
+                    <model predicate="$parameters?mode='toc' and div" behaviour="pass-through">
+                        <param name="content" value="div"/>
+                        <param name="head" value="head"/>
+                        <pb:template xml:space="preserve" xmlns=""><ul><li>
+                            <details><summary>[[head]]</summary><ul>[[content]]</ul></details>
+                        </li></ul></pb:template>
+                    </model>
+                    <model predicate="$parameters?mode='toc'" behaviour="pass-through">
+                        <param name="head" value="head"/>
+                        <pb:template xml:space="preserve" xmlns=""><li>[[head]]</li></pb:template>
+                    </model>
                     <model predicate="$parameters?mode = 'register'" behaviour="pass-through">
                         <desc>Output register data if register profile is enabled</desc>
                         <param name="people" value="let $refs := (root(.)//persName[@key or @ref], root(.)//rs[@type='person'][@key or @ref]), $keys := for $i in ($refs/@key, $refs/@ref) return $i ! tokenize(., ' ')  return for $key in distinct-values($keys) return collection($global:register-root)/id($key)[self::person]"/>
@@ -347,6 +367,7 @@
         </model>
                 </elementSpec>
                 <elementSpec ident="front" mode="change">
+                    <model predicate="$parameters?mode='toc'" behaviour="list"/>
                     <model behaviour="block"/>
                 </elementSpec>
                 <elementSpec ident="fw" mode="change">
@@ -397,6 +418,14 @@
                     <model behaviour="block"/>
                 </elementSpec>
                 <elementSpec ident="head" mode="change">
+                    <model predicate="$parameters?mode='toc' and $parameters?mode-sub='toc-odd'" behaviour="pass-through">
+                        <param name="id" value="parent::div/@xml:id"/>
+                        <param name="hash" value="parent::div/@xml:id"/>
+                        <param name="node-id" value="util:node-id(.)"/>
+                        <pb:template  xml:space="preserve">
+                            <pb-link xmlns="" xml-id="[[id]]" hash="[[hash]]" node-id="[[node-id]]" emit="transcription" subscribe="transcription">[[content]]</pb-link>
+                        </pb:template>
+                    </model>
                     <model predicate="$parameters?display='browse' or $parameters?mode='toc'" behaviour="inline">
                         <desc>For browse view and table of contents, just output inline text</desc>
                     </model>
@@ -439,6 +468,7 @@
                     <model output="typst" behaviour="break">
                         <param name="type" value="'line'"/>
                     </model>
+                    <model predicate="$parameters?mode='toc'" behaviour="omit"/>
                     <modelSequence predicate="@break">
                         <desc>Generated hyphen for line breaks marked as non-word breaking. Can be later toggled on/off as desired.</desc>
                         <model predicate="@break='no'" behaviour="inline" cssClass="lb-hyphen">
@@ -535,6 +565,7 @@
                     <model behaviour="paragraph" useSourceRendition="true"/>
                 </elementSpec>
                 <elementSpec ident="pb" mode="change">
+                    <model predicate="$parameters?mode='toc'" behaviour="omit"/>
                     <model output="print" behaviour="omit"/>
                     <modelSequence output="typst">
                         <desc>Inline page-break marker; @n as margin note</desc>
@@ -835,6 +866,7 @@
                     <model behaviour="document"/>
                 </elementSpec>
                 <elementSpec ident="text" mode="change">
+                    <model predicate="$parameters?mode='toc'" behaviour="block" cssClass="toc"/>
                     <model predicate="$parameters?mode='title'" behaviour="text">
                         <param name="content" value="root($parameters?root)//teiHeader/fileDesc/titleStmt"/>
                     </model>
@@ -1154,7 +1186,7 @@ flex-wrap: wrap;
             <param name="uri" value="head((@key, @ref))"/>
             <param name="target" value="'_blank'"/>
         </model>
-                    <model predicate="$parameters?display='browse' or $parameters?mode='breadcrumb' or $parameters?mode='toc'" behaviour="inline"/>
+                    <model predicate="$parameters?display='browse' or $parameters?mode='breadcrumb' or $parameters?mode='toc'" behaviour="pass-through"/>
                     <model predicate="$parameters?mode='register'" behaviour="pass-through">
             <desc>Register sidebar</desc>
             <param name="content" value="."/>

--- a/profiles/base10/resources/odd/tp.css
+++ b/profiles/base10/resources/odd/tp.css
@@ -229,3 +229,133 @@ p:empty,
 ul:empty {
     display: none;
 }
+
+.toc {
+    font-family: var(--jinks-content-font-family);
+    font-size: var(--jinks-toc-font-size);
+}
+
+.toc ul {
+    padding: 0;
+    margin: 0;
+}
+
+/* Item without child sections */
+.toc ul>li:not(:has(details)) {
+    padding: 0.75rem calc(1rem + 20px) 0.75rem 0.5rem;
+    border: 1px solid transparent;
+    border-radius: 8px;
+}
+
+/* Item with child sections */
+.toc details summary {
+    display: inline-flex;
+    gap: 1rem;
+    width: 100%;
+    padding: 0.75rem 0.5rem 0.75rem .5rem;
+    justify-content: space-between;
+    align-items: center;
+    list-style: none;
+    cursor: pointer;
+    user-select: none;
+    border: 1px solid transparent;
+    border-radius: 8px;
+    /* override pico default */
+    line-height: var(--jinks-line-height);
+}
+
+.toc details summary > pb-link {
+    flex: 1;
+}
+
+.toc ul details>ul>li:not(:has(details)),
+.toc ul details>ul>li>details>summary {
+    padding-left: var(--jinks-toc-indent);
+}
+
+.toc ul details details>ul>li:not(:has(details)),
+.toc ul details details>ul>li>details>summary {
+    padding-left: calc(var(--jinks-toc-indent) * 2);
+}
+
+.toc ul details details details>ul>li:not(:has(details)),
+.toc ul details details details>ul>li>details>summary {
+    padding-left: calc(var(--jinks-toc-indent) * 3);
+}
+
+.toc ul details details details details>ul>li:not(:has(details)),
+.toc ul details details details details>ul>li>details>summary {
+    padding-left: calc(var(--jinks-toc-indent) * 4);
+}
+
+.toc ul details details details details details>ul>li:not(:has(details)),
+.toc ul details details details details details>ul>li>details>summary {
+    padding-left: calc(var(--jinks-toc-indent) * 5);
+}
+
+.toc ul details details details details details details>ul>li:not(:has(details)),
+.toc ul details details details details details details>ul>li>details>summary {
+    padding-left: calc(var(--jinks-toc-indent) * 6);
+}
+
+.toc ul details details details details details details details>ul>li:not(:has(details)),
+.toc ul details details details details details details details>ul>li>details>summary {
+    padding-left: calc(var(--jinks-toc-indent) * 7);
+}
+
+.toc details > summary > pb-link,
+.toc ul > li > pb-link {
+    display: block;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.toc details>summary:has(> .active),
+.toc details:not(:has(summary>.active)) ul>li:has(> .active) {
+    background-color: var(--jinks-color-focus);
+}
+    
+.toc details > summary::after {
+    display: block;
+    content: "";
+    width: 1rem;
+    height: 1rem;
+    float: right;
+    background-image: var(--jinks-dropdown-button-chevron-image);
+    transform: none;
+    background-size: 1rem auto;
+    background-position: right center;
+    background-repeat: no-repeat;
+    margin-inline-start: 0.5rem;
+    padding-right: 1rem;
+}
+
+.toc details[open]>summary::after {
+    transform: rotate(180deg);
+}
+
+.toc details summary:hover,
+.toc ul>li:not(:has(details)):hover {
+    border: 1px solid #CFCDC5;
+    background-color: var(--jinks-form-background-color);
+}
+
+.toc li {
+    list-style-type: none;
+    margin-bottom: 0;
+    padding: 0;
+}
+
+.toc pb-link a {
+    color: var(--pb-link-color);
+    text-decoration: var(--pb-link-text-decoration);
+}
+
+.toc h1, .toc h2, .toc h3, .toc h4, .toc h5 {
+    font-family: var(--jinks-link-font-family);
+}
+
+.toc [slot=collapse-trigger] pb-link {
+    margin-left: 0px;
+}

--- a/profiles/base10/templates/layouts/content.html
+++ b/profiles/base10/templates/layouts/content.html
@@ -42,6 +42,12 @@
     <pb-load class="toc" url="api/document/{doc}/contents?lang=[[page:resolve-language($context)]]&amp;target=transcription&amp;icons=true[[ if ($context?features?toc?collapse) then '&amp;collapse=true' else '' ]]" expand="expand"
         src="document1" subscribe="toc" emit="toc" load-once="load-once" auto="auto"><pb-i18n key="dialogs.loading">Loading</pb-i18n></pb-load>
     [% endif %]
+
+    [% if $context?features?toc-odd?enabled and exists($context?doc) %]
+        <pb-view src="document1" subscribe="none" xpath="//text" view="single" emit="transcription" disable-history="disable-history">
+            <pb-param name="mode" value="toc"/>
+            <pb-param name="mode-sub" value="toc-odd"/>
+        </pb-view>
     [% endif %]
     [% endtemplate %]
 

--- a/profiles/base10/templates/layouts/content.html
+++ b/profiles/base10/templates/layouts/content.html
@@ -42,6 +42,7 @@
     <pb-load class="toc" url="api/document/{doc}/contents?lang=[[page:resolve-language($context)]]&amp;target=transcription&amp;icons=true[[ if ($context?features?toc?collapse) then '&amp;collapse=true' else '' ]]" expand="expand"
         src="document1" subscribe="toc" emit="toc" load-once="load-once" auto="auto"><pb-i18n key="dialogs.loading">Loading</pb-i18n></pb-load>
     [% endif %]
+    [% endif %]
 
     [% if $context?features?toc-odd?enabled and exists($context?doc) %]
         <pb-view src="document1" subscribe="none" xpath="//text" view="single" emit="transcription" disable-history="disable-history">

--- a/schema/jinks.json
+++ b/schema/jinks.json
@@ -376,7 +376,16 @@
                         },
                         "enabled": {
                             "type": "boolean",
-                            "description": "If true, the table of contents will be displayed"
+                            "description": "If true, the XQuery-based table of contents will be displayed"
+                        }
+                    }
+                },
+                "toc-odd": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "If true, the ODD-based table of contents will be displayed"
                         }
                     }
                 },


### PR DESCRIPTION
this PR introduces a `feature.toc-odd` which can be enabled via config/frontmatter when desired

it enables a new block in `before` template, behaving very much like the regular TP toc, but not relying on any XQuery module, solely on ODD processing

`teipublisher.odd` is extended with models for `toc` mode, and in case of TEI `head` elements with additional parameter check to distinguish XQuery-based toc and this new `toc-odd` feature
