### PR TITLE
Iiif config

### DIFF
--- a/profiles/iiif/config.json
+++ b/profiles/iiif/config.json
@@ -32,6 +32,7 @@
                 "regex": "^[^:]+:(.*)",
                 "replace": "$1"
             },
+            "page_label": "'Page ' || $pb/@n",
             "enabled": false
         }
     }

--- a/profiles/iiif/modules/iiif-api.tpl.xql
+++ b/profiles/iiif/modules/iiif-api.tpl.xql
@@ -45,7 +45,7 @@ declare %private function iiif:canvases($doc as node()) {
         map {
             "@id": $iiifc:CANVAS_ID_PREFIX || $id,
             "@type": "sc:Canvas",
-            "label": "Page " || $pb/@n,
+            "label":  [[ $context?features?iiif?page_label ]],
             "width": $info?width,
             "height": $info?height,
             "images": [

--- a/profiles/iiif/modules/iiif-api.xql
+++ b/profiles/iiif/modules/iiif-api.xql
@@ -22,7 +22,7 @@ declare namespace tei="http://www.tei-c.org/ns/1.0";
 
 (:~ Contact the IIIF image api to get the dimensions of an image :)
 declare %private function iiif:image-info($path as xs:string) {
-    let $request := <http:request method="GET" href="{$iiifc:IMAGE_API_BASE}/{$path}/info.json"/>
+    let $request := <http:request method="GET" href="{string-join(($iiifc:IMAGE_API_BASE, $path), '/')}/info.json"/>
     let $response := http:send-request($request)
     return
         if ($response[1]/@status = 200) then
@@ -53,14 +53,14 @@ declare %private function iiif:canvases($doc as node()) {
                     "@type": "oa:Annotation",
                     "motivation": "sc:painting",
                     "resource": map {
-                        "@id": $iiifc:IMAGE_API_BASE || "/" || $id || "/full/full/0/default.jpg",
+                        "@id": string-join(($iiifc:IMAGE_API_BASE, $id), '/') || "/full/max/0/default.jpg",
                         "@type": "dctypes:Image",
                         "format": "image/jpeg",
                         "width": $info?width,
                         "height": $info?height,
                         "service": map {
                             "@context": "http://iiif.io/api/image/2/context.json",
-                            "@id": $iiifc:IMAGE_API_BASE || "/" || $id,
+                            "@id": string-join(($iiifc:IMAGE_API_BASE, $id), '/'),
                             "profile": "http://iiif.io/api/image/2/level2.json"
                         }
                     },

--- a/profiles/iiif/modules/iiif-config.tpl.xqm
+++ b/profiles/iiif/modules/iiif-config.tpl.xqm
@@ -11,7 +11,11 @@ declare namespace tei="http://www.tei-c.org/ns/1.0";
 (:~
  : Base URI of the IIIF image API service to use for the images
  :)
+[% if $context?features?iiif?base_uri %]
 declare variable $iiifc:IMAGE_API_BASE := "[[ $context?features?iiif?base_uri ]]";
+[% else %]
+declare variable $iiifc:IMAGE_API_BASE := ();
+[% endif %]
 
 (:~
  : URL prefix to use for the canvas id

--- a/schema/jinks.json
+++ b/schema/jinks.json
@@ -517,6 +517,10 @@
                             "type": "string",
                             "description": "XPath expression to select the milestone elements pointing to images"
                         },
+                        "page_label": {
+                            "type": "string",
+                            "description": "XPath expression to generate the label for the pages in the IIIF viewer"
+                        },
                         "replace_facs": {
                             "type": "object",
                             "description": "Regular expression applied to the facs attribute of the milestone elements to extract the image identifier",


### PR DESCRIPTION
- add config.json option to control page labels in the IIIF viewer and avoid customizations of iiif-api.xql
- respect empty base_uri